### PR TITLE
Fix critical hit damage modifier being applied twice

### DIFF
--- a/src/pages/paladin/PaladinFunctions.tsx
+++ b/src/pages/paladin/PaladinFunctions.tsx
@@ -18,13 +18,13 @@ export function RollAttack(attackInfo: AttackInfo): AttackRollResult {
 }
 
 export function RollDamage(info: RollDamageInfo): RollDamageResult {
-	const { isCritical, damageDie, damageModifier, hasImprovedDS, isTargetFiendOrUndead, spellSlotUsed } = info;
+	const { isCritical, damageDie, hasImprovedDS, isTargetFiendOrUndead, spellSlotUsed } = info;
 
 	// Perform Weapon Damage
 	const numWeaponDamageRolls = isCritical ? 2 : 1;
 	const weaponDamageRolls = Array.from(
 		{ length: numWeaponDamageRolls },
-		() => Math.ceil(Math.random() * damageDie) + damageModifier
+		() => Math.ceil(Math.random() * damageDie)
 	);
 
 	// Perform Divine Smite Damage Rolls

--- a/src/pages/paladin/RollResultView.tsx
+++ b/src/pages/paladin/RollResultView.tsx
@@ -18,7 +18,7 @@ const RollResultView = (props: RollResultProps) => {
 
 	const maxAttackRoll = Math.max(...toHitValues);
 
-	const totalWeaponDamage = weaponDamageRolls.reduce((a, value) => a + value, 0);
+	const totalWeaponDamage = weaponDamageRolls.reduce((a, value) => a + value, 0) + props.damageModifier;
 	const totalDSDamage = divineSmiteDamageRolls.reduce((a, value) => a + value, 0);
 	const totalDamage = totalWeaponDamage + totalDSDamage;
 


### PR DESCRIPTION
## Summary
On a critical hit, `RollDamage` in `PaladinFunctions.tsx` added `damageModifier` once per rolled die (2x on a crit) instead of once total. Per 5e rules only the damage dice double on a crit, not the flat modifier. Fixed by rolling raw dice and adding the modifier once when totaling in `RollResultView.tsx`.

## Dependencies
None — independent of the other branches in this batch.

🤖 Generated with a multi-agent code review + fix pass