### PR TITLE
Disable Missed button on a natural 20

### DIFF
--- a/src/pages/gloomstalker/AttackSheet/Steps/PostHitRollStep.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Steps/PostHitRollStep.tsx
@@ -51,7 +51,7 @@ export default function PostHitRollStep({ state, dispatch }: PostHitRollStepProp
 			</div>
 			<SheetFooter>
 				<Button onClick={confirmIsHit} disabled={hitStatus === CritStatus.CriticalMiss}>Hit</Button>
-				<Button variant="secondary" onClick={confirmIsMiss}>Missed</Button>
+				<Button variant="secondary" onClick={confirmIsMiss} disabled={hitStatus === CritStatus.CriticalHit}>Missed</Button>
 				<Button variant="outline" onClick={goBack}>Back</Button>
 			</SheetFooter>
 		</>


### PR DESCRIPTION
## Summary
A natural 20 always hits in 5e, but the "Missed" button in `PostHitRollStep.tsx` had no guard preventing a nat 20 from being recorded as a miss. Added a disabled guard mirroring the existing Critical-Miss guard already on the "Hit" button.

## Dependencies
None — independent of the other branches in this batch.

🤖 Generated with a multi-agent code review + fix pass