### PR TITLE
Guard numeric modifier inputs against NaN

### DIFF
--- a/src/pages/gloomstalker/GloomStalkerInfoCard.tsx
+++ b/src/pages/gloomstalker/GloomStalkerInfoCard.tsx
@@ -30,6 +30,7 @@ export default function GloomStalkerInfoCard({ gloomStalkerInfo, onChange, addTo
 	} = gloomStalkerInfo;
 
 	const setAttackModifier = (newValue: number) => {
+		if (Number.isNaN(newValue)) return;
 		onChange({
 			...gloomStalkerInfo,
 			attackModifier: newValue
@@ -37,6 +38,7 @@ export default function GloomStalkerInfoCard({ gloomStalkerInfo, onChange, addTo
 	};
 
 	const setDamageDie = (newValue: number) => {
+		if (Number.isNaN(newValue)) return;
 		onChange({
 			...gloomStalkerInfo,
 			damageDie: newValue
@@ -44,6 +46,7 @@ export default function GloomStalkerInfoCard({ gloomStalkerInfo, onChange, addTo
 	};
 
 	const setDamageModifier = (newValue: number) => {
+		if (Number.isNaN(newValue)) return;
 		onChange({
 			...gloomStalkerInfo,
 			damageModifier: newValue

--- a/src/pages/paladin/PaladinInfoTab.tsx
+++ b/src/pages/paladin/PaladinInfoTab.tsx
@@ -28,6 +28,7 @@ export default function PaladinInfoTab({ paladinInfo, onChange, addToRollHistory
 	const { attackModifier, damageDie, damageModifier, hasImprovedDS } = paladinInfo;
 
 	const setAttackModifier = (newValue: number) => {
+		if (Number.isNaN(newValue)) return;
 		onChange({
 			...paladinInfo,
 			attackModifier: newValue
@@ -35,6 +36,7 @@ export default function PaladinInfoTab({ paladinInfo, onChange, addToRollHistory
 	};
 
 	const setDamageDie = (newValue: number) => {
+		if (Number.isNaN(newValue)) return;
 		onChange({
 			...paladinInfo,
 			damageDie: newValue
@@ -42,6 +44,7 @@ export default function PaladinInfoTab({ paladinInfo, onChange, addToRollHistory
 	};
 
 	const setDamageModifier = (newValue: number) => {
+		if (Number.isNaN(newValue)) return;
 		onChange({
 			...paladinInfo,
 			damageModifier: newValue


### PR DESCRIPTION
## Summary
Clearing a number input, or deselecting the damage-die `ToggleGroup`, produced `NaN`, which got written into state and silently corrupted the persisted localStorage value (`JSON.stringify` turns `NaN` into `null`). Added guards in both `PaladinInfoTab.tsx` and `GloomStalkerInfoCard.tsx` to skip the state update when the parsed value is `NaN`.

## Dependencies
Blocks a queued follow-up: `refactor/shared-weapon-stats-form` is built on top of this once merged. Merge this one first to unblock that branch.

🤖 Generated with a multi-agent code review + fix pass