### PR TITLE
Fix history list index-as-key bug on prepend-only lists

### DIFF
--- a/src/pages/gloomstalker/GloomStalkerHistoryTab.tsx
+++ b/src/pages/gloomstalker/GloomStalkerHistoryTab.tsx
@@ -29,8 +29,8 @@ export default function GloomStalkerHistoryTab({ historyRecords, onClearHistory,
 				<ScrollArea className="h-120 rounded-md border">
 					<div className="p-4">
 						{
-							historyRecords.map((historyRecord, i) =>
-								<React.Fragment key={i}>
+							historyRecords.map((historyRecord) =>
+								<React.Fragment key={historyRecord.timestamp}>
 									{rollRecordRenderer(historyRecord)}
 									<Separator className="my-2" />
 								</React.Fragment>

--- a/src/pages/paladin/PaladinAttackSheet.tsx
+++ b/src/pages/paladin/PaladinAttackSheet.tsx
@@ -51,7 +51,8 @@ export default function PaladinAttackSheet({ paladinInfo, addToRollHistory }: Pa
 			toHitValues: [],
 			isCritical: false,
 			weaponDamageRolls: [],
-			divineSmiteDamageRolls: []
+			divineSmiteDamageRolls: [],
+			timestamp: Date.now()
 		};
 
 		if (attackRollResult) {

--- a/src/pages/paladin/PaladinHistoryTab.tsx
+++ b/src/pages/paladin/PaladinHistoryTab.tsx
@@ -29,8 +29,8 @@ export default function PaladinHistoryTab({ attackResults, onClearHistory, rollR
 				<ScrollArea className="h-120 rounded-md border">
 					<div className="p-4">
 						{
-							attackResults.map((attackResult, i) =>
-								<React.Fragment key={i}>
+							attackResults.map((attackResult) =>
+								<React.Fragment key={attackResult.timestamp}>
 									{rollRecordRenderer(attackResult)}
 									<Separator className="my-2" />
 								</React.Fragment>

--- a/src/pages/paladin/PaladinTypes.tsx
+++ b/src/pages/paladin/PaladinTypes.tsx
@@ -31,4 +31,5 @@ export interface RollDamageResult {
 
 export interface RollHistoryRecord extends PaladinInfo, AttackInfo, AttackRollResult, RollDamageInfo, RollDamageResult {
 	isHit: boolean;
+	timestamp: number;
 }


### PR DESCRIPTION
## Summary
Both history tabs keyed rows on array index while new rolls are prepended to the list, causing React to reuse the wrong row's expanded/collapsed `Collapsible` state once a new roll was added. Gloom-Stalker now keys on the existing `timestamp` field on `HistoryRecord`; Paladin's `RollHistoryRecord` gained a new `timestamp` field for the same purpose, set in `PaladinAttackSheet.tsx`.

## Dependencies
Blocks a queued follow-up: `refactor/shared-history-tab` is built on top of this once merged. Merge this one first to unblock that branch.

🤖 Generated with a multi-agent code review + fix pass