### PR TITLE
Import Label from shadcn wrapper instead of raw Radix primitive

### DIFF
--- a/src/pages/paladin/RollResultView.tsx
+++ b/src/pages/paladin/RollResultView.tsx
@@ -2,7 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { Label } from "@radix-ui/react-label";
+import { Label } from "@/components/ui/label";
 import { ChevronDown } from "lucide-react";
 import { RollHistoryRecord } from "./PaladinTypes";
 import { SpellSlotToString } from "./PaladinFunctions";


### PR DESCRIPTION
## Summary
`RollResultView.tsx` imported `Label` directly from `@radix-ui/react-label` instead of the project's styled `@/components/ui/label` wrapper used everywhere else in the app, causing inconsistent styling (text size, weight, disabled-state opacity, layout).

## Dependencies
None — independent of the other branches in this batch.

🤖 Generated with a multi-agent code review + fix pass