### PR TITLE
Remove stray double semicolon in GetFireDamageDicePool

### DIFF
--- a/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.tsx
+++ b/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.tsx
@@ -173,7 +173,7 @@ export function GetPiercingDamageDicePool(state: GloomStalkerAttackSheetState): 
 }
 
 export function GetFireDamageDicePool(state: GloomStalkerAttackSheetState): number[] {
-	const isCriticalHit = GetCritStatus(state) === CritStatus.CriticalHit;;
+	const isCriticalHit = GetCritStatus(state) === CritStatus.CriticalHit;
 
 	const fireDamageDicePool: number[] = [];
 


### PR DESCRIPTION
## Summary
Trivial cleanup of a duplicated `;;` in `AttackSheetStateFunctions.tsx`.

## Dependencies
None — independent of the other branches in this batch. Note: this overlaps `AttackSheetStateFunctions.tsx` with `fix/gs-reroll-sentinel`, `fix/gs-reroll-once-state`, and `chore/gs-remove-dead-dragonslumber-flag`; expect a trivial manual conflict if merging more than one of these together.

🤖 Generated with a multi-agent code review + fix pass