### PR TITLE
Remove vestigial boolean fields from GloomStalker default storage

### DIFF
--- a/src/pages/gloomstalker/GloomStalkerLocalStorage.tsx
+++ b/src/pages/gloomstalker/GloomStalkerLocalStorage.tsx
@@ -8,12 +8,6 @@ const defaultItem = {
 		attackModifier: 14,
 		damageDie: 8,
 		damageModifier: 9,
-		hasDreadAmbusher: true,
-		hasStalkersFlurry: true,
-		hasSharpShooter: true,
-		hasPiercer: true,
-		hasElvenAccuracy: true,
-		hasDragonsWrathLongbowStirring: true,
 	},
 	historyRecords: []
 };


### PR DESCRIPTION
## Summary
`defaultItem.gloomStalkerInfo` in `GloomStalkerLocalStorage.tsx` included six boolean fields (`hasDreadAmbusher`, `hasStalkersFlurry`, `hasSharpShooter`, `hasPiercer`, `hasElvenAccuracy`, `hasDragonsWrathLongbowStirring`) that don't exist on the `GloomStalkerInfo` type and are never read anywhere. Removed as dead data.

## Dependencies
None — independent of the other branches in this batch.

🤖 Generated with a multi-agent code review + fix pass