### PR TITLE
Deduplicate localStorage reads on page mount

### DIFF
--- a/src/pages/gloomstalker/GloomStalkerPage.tsx
+++ b/src/pages/gloomstalker/GloomStalkerPage.tsx
@@ -7,15 +7,11 @@ import AttackHistoryView from "./AttackHistoryView";
 import GloomStalkerHistoryTab from "./GloomStalkerHistoryTab";
 
 function GloomStalkerPage() {
-	const [gloomStalkerInfo, setGloomStalkerInfo] = useState<GloomStalkerInfo>(() => {
-		const localStorage = GetLocalGloomStalkerStorage();
-		return localStorage.gloomStalkerInfo;
-	});
+	const [localStorageData] = useState(() => GetLocalGloomStalkerStorage());
 
-	const [historyRecords, setHistoryRecords] = useState<HistoryRecord[]>(() => {
-		const localStorage = GetLocalGloomStalkerStorage();
-		return localStorage.historyRecords;
-	});
+	const [gloomStalkerInfo, setGloomStalkerInfo] = useState<GloomStalkerInfo>(localStorageData.gloomStalkerInfo);
+
+	const [historyRecords, setHistoryRecords] = useState<HistoryRecord[]>(localStorageData.historyRecords);
 
 	// On State change, save results to local storage
 	useEffect(() => {

--- a/src/pages/paladin/PaladinPage.tsx
+++ b/src/pages/paladin/PaladinPage.tsx
@@ -7,15 +7,11 @@ import { GetLocalPaladinStorage, SaveLocalPaladinStorage } from "./PaladinLocalS
 import RollResultView from "./RollResultView";
 
 function PaladinPage() {
-	const [paladinInfo, setPaladinInfo] = useState<PaladinInfo>(() => {
-		const localStorage = GetLocalPaladinStorage();
-		return localStorage.paladinInfo;
-	});
+	const [localStorageData] = useState(() => GetLocalPaladinStorage());
 
-	const [attackResults, setAttackResults] = useState<RollHistoryRecord[]>(() => {
-		const localStorage = GetLocalPaladinStorage();
-		return localStorage.attackResults;
-	});
+	const [paladinInfo, setPaladinInfo] = useState<PaladinInfo>(localStorageData.paladinInfo);
+
+	const [attackResults, setAttackResults] = useState<RollHistoryRecord[]>(localStorageData.attackResults);
 
 	// On State change, save results to local storage
 	useEffect(() => {


### PR DESCRIPTION
## Summary
`PaladinPage.tsx` and `GloomStalkerPage.tsx` each called their localStorage getter twice on mount (once per `useState` initializer). Both now read once and derive both pieces of state from the cached result.

## Dependencies
None — independent of the other branches in this batch.

🤖 Generated with a multi-agent code review + fix pass