### PR TITLE
Add styled 404 page with link home

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import Home from './pages/Home/Home.tsx';
-import { BrowserRouter, Routes, Route } from "react-router";
+import { BrowserRouter, Routes, Route, Link } from "react-router";
 import PaladinPage from './pages/paladin/PaladinPage.tsx';
 import MainLayout from './layouts/MainLayout.tsx';
 import GloomStalkerPage from './pages/gloomstalker/GloomStalkerPage.tsx';
@@ -15,7 +15,12 @@ createRoot(document.getElementById('root')!).render(
 					<Route path='/' element={<Home />} />
 					<Route path='paladin' element={<PaladinPage />} />
 					<Route path='gloomstalker' element={<GloomStalkerPage />} />
-					<Route path='*' element={<div>Invalid Route</div>} />
+					<Route path='*' element={
+						<div className="flex flex-col items-center justify-center gap-4 py-24">
+							<h1 className="text-2xl font-semibold">404 - Page Not Found</h1>
+							<Link to="/" className="underline hover:text-neutral-100">Return Home</Link>
+						</div>
+					} />
 				</Route>
 			</Routes>
 		</BrowserRouter>


### PR DESCRIPTION
## Summary
Replaced the bare `<div>Invalid Route</div>` catch-all route with a dark-theme-consistent 404 view and a link back to `/`.

## Dependencies
None — independent of the other branches in this batch.

🤖 Generated with a multi-agent code review + fix pass