### PR TITLE
Indicate the active route in the top nav

### DIFF
--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { Link, Outlet } from "react-router";
+import { Link, Outlet, useLocation } from "react-router";
 import {
 	NavigationMenu,
 	NavigationMenuItem,
@@ -7,23 +7,24 @@ import {
 } from "@/components/ui/navigation-menu";
 
 export default function MainLayout() {
+	const location = useLocation();
 	return (
 		<div className='dark min-w-auto min-h-screen bg-background text-neutral-300'>
 			<NavigationMenu>
 				<NavigationMenuList>
 					<NavigationMenuItem>
 						<NavigationMenuLink asChild>
-							<Link to='/'>Home</Link>
+							<Link to='/' aria-current={location.pathname === '/' ? 'page' : undefined} className={location.pathname === '/' ? 'font-bold text-white' : ''}>Home</Link>
 						</NavigationMenuLink>
 					</NavigationMenuItem>
 					<NavigationMenuItem>
 						<NavigationMenuLink asChild>
-							<Link to='/paladin'>Paladin Attack</Link>
+							<Link to='/paladin' aria-current={location.pathname === '/paladin' ? 'page' : undefined} className={location.pathname === '/paladin' ? 'font-bold text-white' : ''}>Paladin Attack</Link>
 						</NavigationMenuLink>
 					</NavigationMenuItem>
 					<NavigationMenuItem>
 						<NavigationMenuLink asChild>
-							<Link to='/gloomstalker'>Gloom-Stalker</Link>
+							<Link to='/gloomstalker' aria-current={location.pathname === '/gloomstalker' ? 'page' : undefined} className={location.pathname === '/gloomstalker' ? 'font-bold text-white' : ''}>Gloom-Stalker</Link>
 						</NavigationMenuLink>
 					</NavigationMenuItem>
 				</NavigationMenuList>


### PR DESCRIPTION
## Summary
`MainLayout.tsx` had no visual indication of which page was currently active. Added `useLocation()`-based active styling and `aria-current="page"` to the matching nav link.

## Dependencies
None — independent of the other branches in this batch.

🤖 Generated with a multi-agent code review + fix pass