### PR TITLE
Rename RerollPiercingDamageDieCommand to RerollWorstDamageDieCommand

### DIFF
--- a/src/pages/gloomstalker/AttackSheet/Commands/AttackSheetCommands.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Commands/AttackSheetCommands.tsx
@@ -7,7 +7,7 @@ export { default as ConfirmIsMissCommand } from "./ConfirmIsMissCommand";
 export { default as GoBackCommand } from "./GoBackCommand";
 export { default as NullCommand } from "./NullCommand";
 export { default as ResetCommand } from "./ResetCommand";
-export { default as RerollPiercingDamageDieCommand } from "./RerollPiercingDamageDieCommand";
+export { default as RerollWorstDamageDieCommand } from "./RerollWorstDamageDieCommand";
 export { default as RollForAttackCommand } from "./RollForAttackCommand";
 export { default as RollForDamageCommand } from "./RollForDamageCommand";
 export { default as SetAdvantageCommand } from "./SetAdvantageCommand";

--- a/src/pages/gloomstalker/AttackSheet/Commands/RerollWorstDamageDieCommand.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Commands/RerollWorstDamageDieCommand.tsx
@@ -2,7 +2,7 @@ import { GloomStalkerAttackSheetState } from "../../GloomStalkerTypes";
 import { GetBestRerollOption, RollDie } from "../AttackSheetStateFunctions";
 import IGSAttackSheetCommand from "./IGSAttackSheetCommand";
 
-export default class RerollPiercingDamageDieCommand implements IGSAttackSheetCommand {
+export default class RerollWorstDamageDieCommand implements IGSAttackSheetCommand {
 	apply(prevState: GloomStalkerAttackSheetState): GloomStalkerAttackSheetState {
 		const bestRerollOption = GetBestRerollOption(prevState);
 

--- a/src/pages/gloomstalker/AttackSheet/Steps/PostDamageRollStep.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Steps/PostDamageRollStep.tsx
@@ -8,7 +8,7 @@ import {
 	IGSAttackSheetCommand,
 	GoBackCommand,
 	ConfirmDamageCommand,
-	RerollPiercingDamageDieCommand
+	RerollWorstDamageDieCommand
 } from "../Commands/AttackSheetCommands";
 
 interface PostDamageRollStepProps {
@@ -20,7 +20,7 @@ export default function PostDamageRollStep({ state, dispatch }: PostDamageRollSt
 	// Only allow reroll once
 	const [rereollUsed, setRerollUsed] = useState(false);
 
-	const rerollDamageDie = () => dispatch(new RerollPiercingDamageDieCommand());
+	const rerollDamageDie = () => dispatch(new RerollWorstDamageDieCommand());
 	const confirmDamage = () => dispatch(new ConfirmDamageCommand());
 	const goBack = () => dispatch(new GoBackCommand());
 


### PR DESCRIPTION
## Summary
The command rerolls whichever die (piercing or fire) is worst, not just piercing, so the old name was misleading. Pure rename of the class/file plus the barrel export (`AttackSheetCommands.tsx`) and call site (`PostDamageRollStep.tsx`) — no behavior change.

## Dependencies
None — independent of the other branches in this batch. Note: this overlaps `PostDamageRollStep.tsx` / the reroll command file with `fix/gs-reroll-sentinel` and `fix/gs-reroll-once-state`; expect manual conflict resolution if merging more than one of these together.

🤖 Generated with a multi-agent code review + fix pass