### PR TITLE
Clear stale step state in GoBackCommand

### DIFF
--- a/src/pages/gloomstalker/AttackSheet/Commands/GoBackCommand.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Commands/GoBackCommand.tsx
@@ -3,22 +3,30 @@ import IGSAttackSheetCommand from "./IGSAttackSheetCommand";
 
 export default class GoBackCommand implements IGSAttackSheetCommand {
 	apply(prevState: GloomStalkerAttackSheetState): GloomStalkerAttackSheetState {
-		const prevStep = (() => {
-			switch (prevState.attackStep) {
-				case AttackStep.PostHitRoll:
-					return AttackStep.PreHitRoll;
-				case AttackStep.PreDamageRoll:
-					return AttackStep.PostHitRoll;
-				case AttackStep.PostDamageRoll:
-					return AttackStep.PreDamageRoll;
-				default:
-					return prevState.attackStep;
-			}
-		})();
-
-		return {
-			...prevState,
-			attackStep: prevStep,
-		};
+		switch (prevState.attackStep) {
+			case AttackStep.PostHitRoll:
+				return {
+					...prevState,
+					attackStep: AttackStep.PreHitRoll,
+					attackRolls: [],
+					isHit: false,
+				};
+			case AttackStep.PreDamageRoll:
+				return {
+					...prevState,
+					attackStep: AttackStep.PostHitRoll,
+				};
+			case AttackStep.PostDamageRoll:
+				return {
+					...prevState,
+					attackStep: AttackStep.PreDamageRoll,
+					piercingDamageRolls: [],
+					fireDamageRolls: [],
+					piercingDamageDicePool: [],
+					fireDamageDicePool: [],
+				};
+			default:
+				return prevState;
+		}
 	}
 }


### PR DESCRIPTION
## Summary
Navigating back a step didn't clear the fields the abandoned step had populated (stale `attackRolls`/`isHit` when leaving `PostHitRoll`; stale damage rolls/dice pools when leaving `PostDamageRoll`). `GoBackCommand` now clears the relevant fields per transition case.

## Dependencies
None — independent of the other branches in this batch.

🤖 Generated with a multi-agent code review + fix pass