### PR TITLE
Remove dead applyDragonSlumberDamage field

### DIFF
--- a/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.tsx
+++ b/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.tsx
@@ -13,8 +13,7 @@ export function GloomStalkerAttackSheetStateDefault(gloomStalkerInfo: GloomStalk
 		piercingDamageRolls: [],
 		piercingDamageDicePool: [],
 		fireDamageDicePool: [],
-		fireDamageRolls: [],
-		applyDragonSlumberDamage: false
+		fireDamageRolls: []
 	};
 }
 

--- a/src/pages/gloomstalker/GloomStalkerTypes.tsx
+++ b/src/pages/gloomstalker/GloomStalkerTypes.tsx
@@ -31,7 +31,6 @@ export interface PostDamageRollInfo {
 	piercingDamageRolls: number[];
 	fireDamageDicePool: number[];
 	fireDamageRolls: number[];
-	applyDragonSlumberDamage: boolean;  // apply 5 damage to nearby creatures? Only triggered on crit
 }
 
 export enum AttackStep {


### PR DESCRIPTION
## Summary
`applyDragonSlumberDamage` was declared and defaulted but never set by any command and never read — `AttackHistoryDetails.tsx` already shows its associated "Apply 5 Damage to Adjacent Enemies" text unconditionally on every crit, ignoring the flag entirely. Removed as dead state.

## Dependencies
None — independent of the other branches in this batch. Note: this overlaps `AttackSheetStateFunctions.tsx` with `fix/gs-reroll-sentinel`, `fix/gs-reroll-once-state`, and `chore/gs-remove-stray-semicolon`; expect a trivial manual conflict if merging more than one of these together.

🤖 Generated with a multi-agent code review + fix pass