### PR TITLE
Extract shared WeaponStatsForm component

### DIFF
--- a/src/components/WeaponStatsForm.tsx
+++ b/src/components/WeaponStatsForm.tsx
@@ -1,0 +1,83 @@
+import { Input } from "@/components/ui/input";
+import {
+	ToggleGroup,
+	ToggleGroupItem,
+} from "@/components/ui/toggle-group";
+
+const weaponDamageDice = [4, 6, 8, 10, 12];
+
+export interface WeaponStatsFormProps {
+	attackModifier: number;
+	damageDie: number;
+	damageModifier: number;
+	onAttackModifierChange: (value: number) => void;
+	onDamageDieChange: (value: number) => void;
+	onDamageModifierChange: (value: number) => void;
+}
+
+export default function WeaponStatsForm({
+	attackModifier,
+	damageDie,
+	damageModifier,
+	onAttackModifierChange,
+	onDamageDieChange,
+	onDamageModifierChange,
+}: WeaponStatsFormProps) {
+	const handleAttackModifierChange = (newValue: number) => {
+		if (Number.isNaN(newValue)) return;
+		onAttackModifierChange(newValue);
+	};
+
+	const handleDamageDieChange = (newValue: number) => {
+		if (Number.isNaN(newValue)) return;
+		onDamageDieChange(newValue);
+	};
+
+	const handleDamageModifierChange = (newValue: number) => {
+		if (Number.isNaN(newValue)) return;
+		onDamageModifierChange(newValue);
+	};
+
+	return (
+		<>
+			<div>
+				<label>
+					Attack Modifier:
+					<Input
+						type="number"
+						value={attackModifier}
+						onChange={e => handleAttackModifierChange(parseInt(e.target.value))}
+					/>
+				</label>
+			</div>
+			<div>
+				<label>
+					Damage Die:
+				</label>
+				<ToggleGroup
+					type="single"
+					value={damageDie.toString()}
+					onValueChange={newValue => handleDamageDieChange(parseInt(newValue))}
+				>
+					{
+						weaponDamageDice.map((dieValue, i) =>
+							<ToggleGroupItem key={i} value={dieValue.toString()}>
+								d{dieValue}
+							</ToggleGroupItem>
+						)
+					}
+				</ToggleGroup>
+			</div>
+			<div>
+				<label>
+					Damage Modifier
+					<Input
+						type="number"
+						value={damageModifier}
+						onChange={e => handleDamageModifierChange(parseInt(e.target.value))}
+					/>
+				</label>
+			</div>
+		</>
+	);
+}

--- a/src/pages/gloomstalker/GloomStalkerInfoCard.tsx
+++ b/src/pages/gloomstalker/GloomStalkerInfoCard.tsx
@@ -1,8 +1,3 @@
-import { Input } from "@/components/ui/input";
-import {
-	ToggleGroup,
-	ToggleGroupItem,
-} from "@/components/ui/toggle-group";
 import {
 	Card,
 	CardContent,
@@ -13,14 +8,13 @@ import {
 } from "@/components/ui/card";
 import { GloomStalkerInfo, HistoryRecord } from "./GloomStalkerTypes";
 import GloomStalkerAttackSheet from "./GloomStalkerAttackSheet";
+import WeaponStatsForm from "@/components/WeaponStatsForm";
 
 export interface GloomStalkerInfoCardProps {
 	gloomStalkerInfo: GloomStalkerInfo;
 	onChange: (gloomStalkerInfo: GloomStalkerInfo) => void;
 	addToHistory: (historyRecord: HistoryRecord) => void;
 }
-
-const weaponDamageDice = [4, 6, 8, 10, 12];
 
 export default function GloomStalkerInfoCard({ gloomStalkerInfo, onChange, addToHistory }: GloomStalkerInfoCardProps) {
 	const {
@@ -29,30 +23,6 @@ export default function GloomStalkerInfoCard({ gloomStalkerInfo, onChange, addTo
 		damageModifier
 	} = gloomStalkerInfo;
 
-	const setAttackModifier = (newValue: number) => {
-		if (Number.isNaN(newValue)) return;
-		onChange({
-			...gloomStalkerInfo,
-			attackModifier: newValue
-		});
-	};
-
-	const setDamageDie = (newValue: number) => {
-		if (Number.isNaN(newValue)) return;
-		onChange({
-			...gloomStalkerInfo,
-			damageDie: newValue
-		});
-	};
-
-	const setDamageModifier = (newValue: number) => {
-		if (Number.isNaN(newValue)) return;
-		onChange({
-			...gloomStalkerInfo,
-			damageModifier: newValue
-		});
-	};
-
 	return (
 		<Card>
 			<CardHeader>
@@ -60,36 +30,29 @@ export default function GloomStalkerInfoCard({ gloomStalkerInfo, onChange, addTo
 				<CardDescription>Set GloomStalker Info</CardDescription>
 			</CardHeader>
 			<CardContent>
-				<div>
-					<label>
-						Attack Modifier:
-						<Input type="number" value={attackModifier}
-							onChange={e => setAttackModifier(parseInt(e.target.value))} />
-					</label>
-				</div>
-				<div>
-					<label>
-						Damage Die:
-					</label>
-					<ToggleGroup type="single"
-						value={damageDie.toString()}
-						onValueChange={newValue => setDamageDie(parseInt(newValue))}>
-						{
-							weaponDamageDice.map((dieValue, i) =>
-								<ToggleGroupItem key={i} value={dieValue.toString()}>
-									d{dieValue}
-								</ToggleGroupItem>
-							)
-						}
-					</ToggleGroup>
-				</div>
-				<div>
-					<label>
-						Damage Modifier
-						<Input type="number" value={damageModifier}
-							onChange={e => setDamageModifier(parseInt(e.target.value))} />
-					</label>
-				</div>
+				<WeaponStatsForm
+					attackModifier={attackModifier}
+					damageDie={damageDie}
+					damageModifier={damageModifier}
+					onAttackModifierChange={(newValue) =>
+						onChange({
+							...gloomStalkerInfo,
+							attackModifier: newValue
+						})
+					}
+					onDamageDieChange={(newValue) =>
+						onChange({
+							...gloomStalkerInfo,
+							damageDie: newValue
+						})
+					}
+					onDamageModifierChange={(newValue) =>
+						onChange({
+							...gloomStalkerInfo,
+							damageModifier: newValue
+						})
+					}
+				/>
 			</CardContent>
 			<CardFooter>
 				<GloomStalkerAttackSheet

--- a/src/pages/paladin/PaladinInfoTab.tsx
+++ b/src/pages/paladin/PaladinInfoTab.tsx
@@ -1,9 +1,4 @@
 import { Checkbox } from "@/components/ui/checkbox";
-import { Input } from "@/components/ui/input";
-import {
-	ToggleGroup,
-	ToggleGroupItem,
-} from "@/components/ui/toggle-group";
 import {
 	Card,
 	CardContent,
@@ -15,6 +10,7 @@ import {
 import { PaladinInfo, RollHistoryRecord } from "./PaladinTypes";
 import PaladinAttackSheet from "./PaladinAttackSheet";
 import { Label } from "@/components/ui/label";
+import WeaponStatsForm from "@/components/WeaponStatsForm";
 
 export interface PaladinInfoTabProps {
 	paladinInfo: PaladinInfo;
@@ -22,34 +18,8 @@ export interface PaladinInfoTabProps {
 	addToRollHistory: (result: RollHistoryRecord) => void;
 }
 
-const weaponDamageDice = [4, 6, 8, 10, 12];
-
 export default function PaladinInfoTab({ paladinInfo, onChange, addToRollHistory }: PaladinInfoTabProps) {
 	const { attackModifier, damageDie, damageModifier, hasImprovedDS } = paladinInfo;
-
-	const setAttackModifier = (newValue: number) => {
-		if (Number.isNaN(newValue)) return;
-		onChange({
-			...paladinInfo,
-			attackModifier: newValue
-		});
-	};
-
-	const setDamageDie = (newValue: number) => {
-		if (Number.isNaN(newValue)) return;
-		onChange({
-			...paladinInfo,
-			damageDie: newValue
-		});
-	};
-
-	const setDamageModifier = (newValue: number) => {
-		if (Number.isNaN(newValue)) return;
-		onChange({
-			...paladinInfo,
-			damageModifier: newValue
-		});
-	};
 
 	const setHasImprovedDS = (newValue: boolean) => {
 		onChange({
@@ -65,36 +35,29 @@ export default function PaladinInfoTab({ paladinInfo, onChange, addToRollHistory
 				<CardDescription>Set Paladin Info</CardDescription>
 			</CardHeader>
 			<CardContent>
-				<div>
-					<label>
-						Attack Modifier:
-						<Input type="number" value={attackModifier}
-							onChange={e => setAttackModifier(parseInt(e.target.value))} />
-					</label>
-				</div>
-				<div>
-					<label>
-						Damage Die:
-					</label>
-					<ToggleGroup type="single"
-						value={damageDie.toString()}
-						onValueChange={newValue => setDamageDie(parseInt(newValue))}>
-						{
-							weaponDamageDice.map((dieValue, i) =>
-								<ToggleGroupItem key={i} value={dieValue.toString()}>
-									d{dieValue}
-								</ToggleGroupItem>
-							)
-						}
-					</ToggleGroup>
-				</div>
-				<div>
-					<label>
-						Damage Modifier
-						<Input type="number" value={damageModifier}
-							onChange={e => setDamageModifier(parseInt(e.target.value))} />
-					</label>
-				</div>
+				<WeaponStatsForm
+					attackModifier={attackModifier}
+					damageDie={damageDie}
+					damageModifier={damageModifier}
+					onAttackModifierChange={(newValue) =>
+						onChange({
+							...paladinInfo,
+							attackModifier: newValue
+						})
+					}
+					onDamageDieChange={(newValue) =>
+						onChange({
+							...paladinInfo,
+							damageDie: newValue
+						})
+					}
+					onDamageModifierChange={(newValue) =>
+						onChange({
+							...paladinInfo,
+							damageModifier: newValue
+						})
+					}
+				/>
 				<div title="Automaticlly adds 1d8 Radiant Damage on any attack">
 					<Label htmlFor="hasImprovedDS">
 						<Checkbox id="hasImprovedDS" checked={hasImprovedDS}


### PR DESCRIPTION
## Summary
`PaladinInfoTab.tsx` and `GloomStalkerInfoCard.tsx` had near-identical attack-modifier / damage-die / damage-modifier form fields, including a duplicated `weaponDamageDice` array and the same NaN-guard logic. Extracted a shared `src/components/WeaponStatsForm.tsx` component (with the NaN guard built in) used by both, leaving Paladin's `hasImprovedDS` checkbox and each page's attack-sheet trigger as page-specific additions around it. Pure refactor — no behavior or visual change.

## Dependencies
Depends on `fix/numeric-input-nan-guard` having been merged into `development` first (it was — this branch builds on top of that fix). No other outstanding dependencies.

🤖 Generated with a multi-agent code review + fix pass