### PR TITLE
Change Hunter's Mark damage to Force

### DIFF
--- a/src/pages/gloomstalker/AttackHistoryDetails.tsx
+++ b/src/pages/gloomstalker/AttackHistoryDetails.tsx
@@ -15,7 +15,8 @@ export default function AttackHistoryDetails({ historyRecord }: { historyRecord:
 		+ gloomStalkerInfo.damageModifier
 		+ (historyRecord.applySharpShooterPenalty ? 10 : 0);
 	const totalFireDamage = historyRecord.fireDamageRolls.reduce((a, value) => a + value, 0);
-	const totalDamage = totalPiercingDamage + totalFireDamage;
+	const totalForceDamage = historyRecord.forceDamageRolls.reduce((a, value) => a + value, 0);
+	const totalDamage = totalPiercingDamage + totalFireDamage + totalForceDamage;
 
 	const damageSummary = (
 		<Fragment key="damageSummary">
@@ -27,6 +28,9 @@ export default function AttackHistoryDetails({ historyRecord }: { historyRecord:
 			</li>
 			<li>
 				<Label>Total Fire Damage: {totalFireDamage}</Label>
+			</li>
+			<li>
+				<Label>Total Force Damage: {totalForceDamage}</Label>
 			</li>
 			{hitStatus === CritStatus.CriticalHit && (
 				<li>
@@ -86,7 +90,7 @@ export default function AttackHistoryDetails({ historyRecord }: { historyRecord:
 			)}
 			{historyRecord.applyHuntersMark && (
 				<li>
-					<Label>Hunter's Mark added 1d6 Piercing</Label>
+					<Label>Hunter's Mark added 1d6 Force</Label>
 				</li>
 			)}
 			{historyRecord.isDreadAmbusherExtraAttack && (
@@ -105,6 +109,12 @@ export default function AttackHistoryDetails({ historyRecord }: { historyRecord:
 			</li>
 			<li>
 				<Label>Fire Damage Rolls: {RollArrayToString(historyRecord.fireDamageRolls)}</Label>
+			</li>
+			<li>
+				<Label>Force Damage Dice: {diceArrayToString(historyRecord.forceDamageDicePool)}</Label>
+			</li>
+			<li>
+				<Label>Force Damage Rolls: {RollArrayToString(historyRecord.forceDamageRolls)}</Label>
 			</li>
 			{historyRecord.applySharpShooterPenalty && (
 				<li>

--- a/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.test.tsx
+++ b/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.test.tsx
@@ -13,7 +13,7 @@ import {
 	GetPiercingDamageDicePool,
 	RollHitDice,
 } from './AttackSheetStateFunctions';
-import { CritStatus } from '../GloomStalkerTypes';
+import { CritStatus, DamageType } from '../GloomStalkerTypes';
 import { buildTestState, testGloomStalkerInfo } from './test/fixtures';
 
 describe('GetBestRerollOption', () => {
@@ -35,7 +35,7 @@ describe('GetBestRerollOption', () => {
 		expect(GetBestRerollOption(state)).toEqual({
 			dieSize: 8,
 			roll: 1,
-			type: 'piercing',
+			type: DamageType.Piercing,
 			dicePoolIndex: 0,
 		});
 	});
@@ -49,7 +49,7 @@ describe('GetBestRerollOption', () => {
 		expect(GetBestRerollOption(state)).toEqual({
 			dieSize: 12,
 			roll: 1,
-			type: 'piercing',
+			type: DamageType.Piercing,
 			dicePoolIndex: 1,
 		});
 	});

--- a/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.test.tsx
+++ b/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.test.tsx
@@ -4,6 +4,7 @@ import {
 	GetBestRerollOption,
 	GetCritStatus,
 	GetFireDamageDicePool,
+	GetForceDamageDicePool,
 	GetHighestHitRoll,
 	GetHighestHitValue,
 	GetHitPreConfirmStatusColorClass,
@@ -136,9 +137,9 @@ describe('GetPiercingDamageDicePool', () => {
 		expect(GetPiercingDamageDicePool(state)).toEqual([8, 8]);
 	});
 
-	it("adds a d6 for Hunter's Mark", () => {
+	it("is unaffected by Hunter's Mark (now Force damage)", () => {
 		const state = buildTestState({ attackRolls: [10], applyHuntersMark: true });
-		expect(GetPiercingDamageDicePool(state)).toEqual([8, 6]);
+		expect(GetPiercingDamageDicePool(state)).toEqual([8]);
 	});
 
 	it('doubles the pool and adds one more weapon die on a critical hit', () => {
@@ -146,13 +147,29 @@ describe('GetPiercingDamageDicePool', () => {
 		expect(GetPiercingDamageDicePool(state)).toEqual([8, 8, 8]);
 	});
 
-	it('combines Dread Ambusher, Hunter\'s Mark, and a crit', () => {
+	it('combines Dread Ambusher and a crit', () => {
 		const state = buildTestState({
 			attackRolls: [20],
 			isDreadAmbusherExtraAttack: true,
-			applyHuntersMark: true,
 		});
-		expect(GetPiercingDamageDicePool(state)).toEqual([8, 8, 6, 8, 8, 6, 8]);
+		expect(GetPiercingDamageDicePool(state)).toEqual([8, 8, 8, 8, 8]);
+	});
+});
+
+describe('GetForceDamageDicePool', () => {
+	it("returns an empty pool when Hunter's Mark is not applied", () => {
+		const state = buildTestState({ attackRolls: [10] });
+		expect(GetForceDamageDicePool(state)).toEqual([]);
+	});
+
+	it("adds a d6 when Hunter's Mark is applied", () => {
+		const state = buildTestState({ attackRolls: [10], applyHuntersMark: true });
+		expect(GetForceDamageDicePool(state)).toEqual([6]);
+	});
+
+	it('doubles the pool on a critical hit', () => {
+		const state = buildTestState({ attackRolls: [20], applyHuntersMark: true });
+		expect(GetForceDamageDicePool(state)).toEqual([6, 6]);
 	});
 });
 

--- a/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.tsx
+++ b/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.tsx
@@ -1,4 +1,4 @@
-import { GloomStalkerInfo, GloomStalkerAttackSheetState, AttackStep, HistoryRecord, CritStatus } from "../GloomStalkerTypes";
+import { GloomStalkerInfo, GloomStalkerAttackSheetState, AttackStep, HistoryRecord, CritStatus, DamageType } from "../GloomStalkerTypes";
 import { RollDie } from "@/utils/Dice";
 
 export function GloomStalkerAttackSheetStateDefault(gloomStalkerInfo: GloomStalkerInfo): GloomStalkerAttackSheetState {
@@ -24,7 +24,7 @@ export function GloomStalkerAttackSheetStateDefault(gloomStalkerInfo: GloomStalk
 export interface RolledDie {
 	dieSize: number;
 	roll: number;
-	type: string;
+	type: DamageType;
 	dicePoolIndex: number;
 }
 
@@ -33,9 +33,9 @@ export interface RolledDie {
 // Tiebreaker goes to the highest die (e.g. it's better to reroll a 1 on a d12 than a 1 on a d6)
 export function GetBestRerollOption(state: GloomStalkerAttackSheetState): RolledDie | null {
 	const allRolls: RolledDie[] = [
-		...state.piercingDamageRolls.map((roll, i) => ({ roll, dieSize: state.piercingDamageDicePool[i], type: 'piercing', dicePoolIndex: i })),
-		...state.fireDamageRolls.map((roll, i) => ({ roll, dieSize: state.fireDamageDicePool[i], type: 'fire', dicePoolIndex: i })),
-		...state.forceDamageRolls.map((roll, i) => ({ roll, dieSize: state.forceDamageDicePool[i], type: 'force', dicePoolIndex: i }))
+		...state.piercingDamageRolls.map((roll, i) => ({ roll, dieSize: state.piercingDamageDicePool[i], type: DamageType.Piercing, dicePoolIndex: i })),
+		...state.fireDamageRolls.map((roll, i) => ({ roll, dieSize: state.fireDamageDicePool[i], type: DamageType.Fire, dicePoolIndex: i })),
+		...state.forceDamageRolls.map((roll, i) => ({ roll, dieSize: state.forceDamageDicePool[i], type: DamageType.Force, dicePoolIndex: i }))
 	];
 
 	const rerollableRolls = allRolls.filter(r => r.roll < r.dieSize);

--- a/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.tsx
+++ b/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.tsx
@@ -15,6 +15,8 @@ export function GloomStalkerAttackSheetStateDefault(gloomStalkerInfo: GloomStalk
 		piercingDamageDicePool: [],
 		fireDamageDicePool: [],
 		fireDamageRolls: [],
+		forceDamageDicePool: [],
+		forceDamageRolls: [],
 		hasUsedReroll: false
 	};
 }
@@ -32,7 +34,8 @@ export interface RolledDie {
 export function GetBestRerollOption(state: GloomStalkerAttackSheetState): RolledDie | null {
 	const allRolls: RolledDie[] = [
 		...state.piercingDamageRolls.map((roll, i) => ({ roll, dieSize: state.piercingDamageDicePool[i], type: 'piercing', dicePoolIndex: i })),
-		...state.fireDamageRolls.map((roll, i) => ({ roll, dieSize: state.fireDamageDicePool[i], type: 'fire', dicePoolIndex: i }))
+		...state.fireDamageRolls.map((roll, i) => ({ roll, dieSize: state.fireDamageDicePool[i], type: 'fire', dicePoolIndex: i })),
+		...state.forceDamageRolls.map((roll, i) => ({ roll, dieSize: state.forceDamageDicePool[i], type: 'force', dicePoolIndex: i }))
 	];
 
 	const rerollableRolls = allRolls.filter(r => r.roll < r.dieSize);
@@ -135,7 +138,6 @@ export function RollHitDice(hasAdvantage: boolean, rng: () => number = Math.rand
 export function GetPiercingDamageDicePool(state: GloomStalkerAttackSheetState): number[] {
 	const {
 		isDreadAmbusherExtraAttack,
-		applyHuntersMark,
 	} = state;
 
 	const {
@@ -152,10 +154,6 @@ export function GetPiercingDamageDicePool(state: GloomStalkerAttackSheetState): 
 	// Dread Ambusher Bonus: If it's the first turn of combat, and the attack is the first attack of the turn, then Dread Ambusher adds an additional weapon damage
 	if (isDreadAmbusherExtraAttack) {
 		piercingDamageDicePool.push(damageDie);
-	}
-
-	if (applyHuntersMark) {
-		piercingDamageDicePool.push(6);   // Hunter's Mark adds 1d6 damage on hit
 	}
 
 	if (isCriticalHit) {
@@ -181,4 +179,22 @@ export function GetFireDamageDicePool(state: GloomStalkerAttackSheetState): numb
 	}
 
 	return fireDamageDicePool;
+}
+
+export function GetForceDamageDicePool(state: GloomStalkerAttackSheetState): number[] {
+	const { applyHuntersMark } = state;
+
+	const isCriticalHit = GetCritStatus(state) === CritStatus.CriticalHit;
+
+	const forceDamageDicePool: number[] = [];
+
+	if (applyHuntersMark) {
+		forceDamageDicePool.push(6);   // Hunter's Mark adds 1d6 Force damage on hit
+	}
+
+	if (isCriticalHit) {
+		forceDamageDicePool.push(...forceDamageDicePool);   // on a critical hit, you roll all of the attack's damage dice an additional time
+	}
+
+	return forceDamageDicePool;
 }

--- a/src/pages/gloomstalker/AttackSheet/Commands/GoBackCommand.test.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Commands/GoBackCommand.test.tsx
@@ -28,6 +28,8 @@ describe('GoBackCommand', () => {
 			piercingDamageRolls: [5],
 			fireDamageDicePool: [6],
 			fireDamageRolls: [3],
+			forceDamageDicePool: [6],
+			forceDamageRolls: [2],
 		});
 		const result = new GoBackCommand().apply(state);
 
@@ -36,6 +38,8 @@ describe('GoBackCommand', () => {
 		expect(result.piercingDamageRolls).toEqual([]);
 		expect(result.fireDamageDicePool).toEqual([]);
 		expect(result.fireDamageRolls).toEqual([]);
+		expect(result.forceDamageDicePool).toEqual([]);
+		expect(result.forceDamageRolls).toEqual([]);
 	});
 
 	it('is a no-op from any other step', () => {

--- a/src/pages/gloomstalker/AttackSheet/Commands/GoBackCommand.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Commands/GoBackCommand.tsx
@@ -24,6 +24,8 @@ export default class GoBackCommand implements IGSAttackSheetCommand {
 					fireDamageRolls: [],
 					piercingDamageDicePool: [],
 					fireDamageDicePool: [],
+					forceDamageRolls: [],
+					forceDamageDicePool: [],
 				};
 			default:
 				return prevState;

--- a/src/pages/gloomstalker/AttackSheet/Commands/RerollWorstDamageDieCommand.test.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Commands/RerollWorstDamageDieCommand.test.tsx
@@ -44,4 +44,22 @@ describe('RerollWorstDamageDieCommand', () => {
 		expect(result.piercingDamageRolls).toEqual([6]);
 		expect(result.hasUsedReroll).toBe(true);
 	});
+
+	it('rerolls the worst force die when no piercing/fire die is rerollable', () => {
+		const state = buildTestState({
+			piercingDamageDicePool: [6],
+			piercingDamageRolls: [6],
+			fireDamageDicePool: [6],
+			fireDamageRolls: [6],
+			forceDamageDicePool: [6],
+			forceDamageRolls: [1],
+		});
+
+		const result = new RerollWorstDamageDieCommand(() => 0.5).apply(state);
+
+		expect(result.forceDamageRolls).toEqual([4]);
+		expect(result.piercingDamageRolls).toEqual([6]);
+		expect(result.fireDamageRolls).toEqual([6]);
+		expect(result.hasUsedReroll).toBe(true);
+	});
 });

--- a/src/pages/gloomstalker/AttackSheet/Commands/RerollWorstDamageDieCommand.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Commands/RerollWorstDamageDieCommand.tsx
@@ -1,4 +1,4 @@
-import { GloomStalkerAttackSheetState } from "../../GloomStalkerTypes";
+import { DamageType, GloomStalkerAttackSheetState } from "../../GloomStalkerTypes";
 import { GetBestRerollOption } from "../AttackSheetStateFunctions";
 import { RollDie } from "@/utils/Dice";
 import IGSAttackSheetCommand from "./IGSAttackSheetCommand";
@@ -13,7 +13,7 @@ export default class RerollWorstDamageDieCommand implements IGSAttackSheetComman
 			return { ...prevState };
 		}
 
-		if (bestRerollOption.type === 'piercing') {
+		if (bestRerollOption.type === DamageType.Piercing) {
 			const newPiercingDamageRolls = [...prevState.piercingDamageRolls];
 			newPiercingDamageRolls[bestRerollOption.dicePoolIndex] = RollDie(bestRerollOption.dieSize, this.rng);
 			return {
@@ -21,7 +21,7 @@ export default class RerollWorstDamageDieCommand implements IGSAttackSheetComman
 				piercingDamageRolls: newPiercingDamageRolls,
 				hasUsedReroll: true,
 			};
-		} else if (bestRerollOption.type === 'fire') {
+		} else if (bestRerollOption.type === DamageType.Fire) {
 			const newFireDamageRolls = [...prevState.fireDamageRolls];
 			newFireDamageRolls[bestRerollOption.dicePoolIndex] = RollDie(bestRerollOption.dieSize, this.rng);
 			return {
@@ -29,7 +29,7 @@ export default class RerollWorstDamageDieCommand implements IGSAttackSheetComman
 				fireDamageRolls: newFireDamageRolls,
 				hasUsedReroll: true,
 			};
-		} else if (bestRerollOption.type === 'force') {
+		} else if (bestRerollOption.type === DamageType.Force) {
 			const newForceDamageRolls = [...prevState.forceDamageRolls];
 			newForceDamageRolls[bestRerollOption.dicePoolIndex] = RollDie(bestRerollOption.dieSize, this.rng);
 			return {

--- a/src/pages/gloomstalker/AttackSheet/Commands/RerollWorstDamageDieCommand.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Commands/RerollWorstDamageDieCommand.tsx
@@ -29,6 +29,14 @@ export default class RerollWorstDamageDieCommand implements IGSAttackSheetComman
 				fireDamageRolls: newFireDamageRolls,
 				hasUsedReroll: true,
 			};
+		} else if (bestRerollOption.type === 'force') {
+			const newForceDamageRolls = [...prevState.forceDamageRolls];
+			newForceDamageRolls[bestRerollOption.dicePoolIndex] = RollDie(bestRerollOption.dieSize, this.rng);
+			return {
+				...prevState,
+				forceDamageRolls: newForceDamageRolls,
+				hasUsedReroll: true,
+			};
 		}
 
 		// If for some reason there are no valid reroll options, return the state unchanged

--- a/src/pages/gloomstalker/AttackSheet/Commands/RollForDamageCommand.test.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Commands/RollForDamageCommand.test.tsx
@@ -12,6 +12,8 @@ describe('RollForDamageCommand', () => {
 		expect(result.piercingDamageRolls).toEqual([5]);
 		expect(result.fireDamageDicePool).toEqual([6]);
 		expect(result.fireDamageRolls).toEqual([4]);
+		expect(result.forceDamageDicePool).toEqual([]);
+		expect(result.forceDamageRolls).toEqual([]);
 		expect(result.attackStep).toBe(AttackStep.PostDamageRoll);
 		expect(result.hasUsedReroll).toBe(false);
 	});
@@ -22,5 +24,13 @@ describe('RollForDamageCommand', () => {
 
 		expect(result.piercingDamageDicePool).toEqual([8, 8, 8]);
 		expect(result.fireDamageDicePool).toEqual([6, 6]);
+	});
+
+	it("builds and rolls the force pool when Hunter's Mark is applied", () => {
+		const state = buildTestState({ attackRolls: [10], applyHuntersMark: true });
+		const result = new RollForDamageCommand(() => 0.5).apply(state);
+
+		expect(result.forceDamageDicePool).toEqual([6]);
+		expect(result.forceDamageRolls).toEqual([4]);
 	});
 });

--- a/src/pages/gloomstalker/AttackSheet/Commands/RollForDamageCommand.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Commands/RollForDamageCommand.tsx
@@ -1,5 +1,5 @@
 import { GloomStalkerAttackSheetState, AttackStep } from "../../GloomStalkerTypes";
-import { GetFireDamageDicePool, GetPiercingDamageDicePool } from "../AttackSheetStateFunctions";
+import { GetFireDamageDicePool, GetForceDamageDicePool, GetPiercingDamageDicePool } from "../AttackSheetStateFunctions";
 import { RollDice } from "@/utils/Dice";
 import IGSAttackSheetCommand from "./IGSAttackSheetCommand";
 
@@ -9,6 +9,7 @@ export default class RollForDamageCommand implements IGSAttackSheetCommand {
 	apply(prevState: GloomStalkerAttackSheetState): GloomStalkerAttackSheetState {
 		const piercingDamageDicePool = GetPiercingDamageDicePool(prevState);
 		const fireDamageDicePool = GetFireDamageDicePool(prevState);
+		const forceDamageDicePool = GetForceDamageDicePool(prevState);
 
 		return {
 			...prevState,
@@ -17,6 +18,8 @@ export default class RollForDamageCommand implements IGSAttackSheetCommand {
 			piercingDamageRolls: RollDice(piercingDamageDicePool, this.rng),
 			fireDamageDicePool,
 			fireDamageRolls: RollDice(fireDamageDicePool, this.rng),
+			forceDamageDicePool,
+			forceDamageRolls: RollDice(forceDamageDicePool, this.rng),
 			hasUsedReroll: false,
 		};
 	}

--- a/src/pages/gloomstalker/AttackSheet/Steps/PostDamageRollStep.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Steps/PostDamageRollStep.tsx
@@ -52,6 +52,7 @@ export default function PostDamageRollStep({ state, dispatch }: PostDamageRollSt
 			<div className="grid flex-1 auto-rows-min gap-6 px-4">
 				<Label>Piercing Damage Rolls: [{formatDieRolls(state.piercingDamageRolls, state.piercingDamageDicePool)}]</Label>
 				<Label>Fire Damage Rolls: [{formatDieRolls(state.fireDamageRolls, state.fireDamageDicePool)}]</Label>
+				<Label>Force Damage Rolls: [{formatDieRolls(state.forceDamageRolls, state.forceDamageDicePool)}]</Label>
 				<Button onClick={handleReroll} disabled={state.hasUsedReroll || alreadyBestRolls}>
 					{rerollButtonText}
 				</Button>

--- a/src/pages/gloomstalker/GloomStalkerLocalStorage.tsx
+++ b/src/pages/gloomstalker/GloomStalkerLocalStorage.tsx
@@ -2,7 +2,7 @@ import { GetLocalStorage, ILocalStorageItem, SaveLocalStorage } from "@/utils/Lo
 import { GloomStalkerInfo, HistoryRecord } from "./GloomStalkerTypes";
 
 const storageKey = 'gloomstalker-storage';
-const storageVersion = '0.1';
+const storageVersion = '0.2';
 const defaultItem = {
 	gloomStalkerInfo: {
 		attackModifier: 14,

--- a/src/pages/gloomstalker/GloomStalkerTypes.tsx
+++ b/src/pages/gloomstalker/GloomStalkerTypes.tsx
@@ -31,6 +31,8 @@ export interface PostDamageRollInfo {
 	piercingDamageRolls: number[];
 	fireDamageDicePool: number[];
 	fireDamageRolls: number[];
+	forceDamageDicePool: number[];
+	forceDamageRolls: number[];
 }
 
 export enum AttackStep {

--- a/src/pages/gloomstalker/GloomStalkerTypes.tsx
+++ b/src/pages/gloomstalker/GloomStalkerTypes.tsx
@@ -58,3 +58,9 @@ export enum CritStatus {
 	CriticalMiss,
 	Normal
 }
+
+export enum DamageType {
+	Piercing = 'piercing',
+	Fire = 'fire',
+	Force = 'force'
+}


### PR DESCRIPTION
## Summary
- Adds a `forceDamageDicePool`/`forceDamageRolls` pair to the Gloom-Stalker attack sheet state, mirroring the existing `fireDamage*` pattern
- Moves Hunter's Mark's bonus 1d6 out of the weapon's `piercingDamage*` pool into the new force pool
- Threads the new pool through `RollForDamageCommand`, `RerollWorstDamageDieCommand`, and `GoBackCommand`
- Updates the Post-Damage-Roll step and History detail view to show Force damage separately, and relabels Hunter's Mark as Force instead of Piercing
- Bumps the Gloom-Stalker `storageVersion` (0.1 → 0.2) since old persisted history records lack the new fields

## Justification
Hunter's Mark's extra damage should read as its own damage type (Force) rather than being folded into the weapon's Piercing damage total, since damage type in this codebase is tracked structurally (a dedicated dice-pool/rolls pair per type) rather than via a tagged field.

## Test plan
- [x] `npm run test` — 100/100 passing, including new coverage for `GetForceDamageDicePool` and the force pool through roll/reroll/go-back commands
- [x] `npm run build` — type-checks and builds cleanly
- [x] `npm run lint` — no new warnings/errors
- [x] Independent code review of the branch — no correctness issues found (flagged only a pre-existing copy-paste pattern across piercing/fire/force as a candidate for future refactor, out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)