### PR TITLE
Show semantic hit-status text in Paladin history rows

### DIFF
--- a/src/pages/paladin/AttackHistoryView.tsx
+++ b/src/pages/paladin/AttackHistoryView.tsx
@@ -2,7 +2,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { Button } from "@/components/ui/button";
 import { ChevronDown } from "lucide-react";
 import { HistoryRecord } from "./PaladinTypes";
-import { GetHighestAttackValue, GetHitPreConfirmStatusColorClass, GetTotalDamage } from "./AttackSheet/AttackSheetStateFunctions";
+import { GetHitStatusColorClass, GetHitStatusText } from "./AttackSheet/AttackSheetStateFunctions";
 import AttackHistoryDetails from "./AttackHistoryDetails";
 
 interface AttackHistoryViewProps {
@@ -11,17 +11,15 @@ interface AttackHistoryViewProps {
 }
 
 export default function AttackHistoryView({ defaultOpen, historyRecord }: AttackHistoryViewProps) {
-	const highestAttackValue = GetHighestAttackValue(historyRecord);
-	const totalDamage = GetTotalDamage(historyRecord);
-	const hitValueTextColorClass = GetHitPreConfirmStatusColorClass(historyRecord);
+	const hitText = GetHitStatusText(historyRecord);
+	const hitTextColorClass = GetHitStatusColorClass(historyRecord);
 
 	return (
 		<Collapsible defaultOpen={defaultOpen ?? false} className="group/collapsible">
 			<CollapsibleTrigger asChild className="w-full">
 				<Button variant="ghost">
 					<h3>
-						To Hit: <span className={hitValueTextColorClass}>{highestAttackValue}</span>&nbsp;
-						Damage: <span className="text-red-500">{totalDamage}</span>
+						<span className={hitTextColorClass}>{hitText}</span> - {new Date(historyRecord.timestamp).toLocaleString()}
 					</h3>
 					<ChevronDown className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-180" />
 				</Button>


### PR DESCRIPTION
## Summary
- Paladin's collapsed roll-history row now shows colored Hit/Miss/Critical Hit text plus a timestamp, instead of raw "To Hit: N Damage: N" numbers.
- Reuses `GetHitStatusText`/`GetHitStatusColorClass`, which already existed in `AttackSheetStateFunctions.tsx` but were unused.

## Justification
Matches the equivalent Gloomstalker component (`AttackHistoryView.tsx`), which already uses this pattern. As a side effect, this also fixes a latent bug: the old color helper (`GetHitPreConfirmStatusColorClass`) always rendered non-critical rolls green regardless of hit/miss, so missed attacks showed green in history; the new helper correctly shows red for misses.

Presentation-only — no game logic, state, or command changes. The numeric to-hit/damage detail remains visible when a row is expanded.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run test`
- [x] Independent code review of the commit (clean, no findings)
- [ ] Manual check in a running app: roll a hit, a miss, and a critical hit on `/paladin`, confirm the collapsed history row shows the right colored text + timestamp, and the expanded detail view is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)