### PR TITLE
Show Critical Hit as a conditional label instead of a checkbox

### DIFF
--- a/src/pages/paladin/AttackHistoryDetails.tsx
+++ b/src/pages/paladin/AttackHistoryDetails.tsx
@@ -3,13 +3,12 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Fragment } from "react";
 import { HistoryRecord } from "./PaladinTypes";
-import { GetIsCritical, GetTotalDivineSmiteDamage, GetTotalWeaponDamage, SpellSlotToString } from "./AttackSheet/AttackSheetStateFunctions";
+import { GetHitStatusText, GetTotalDivineSmiteDamage, GetTotalWeaponDamage, SpellSlotToString } from "./AttackSheet/AttackSheetStateFunctions";
 import { JoinWithElement, RollArrayToString } from "@/utils/Formatting";
 
 export default function AttackHistoryDetails({ historyRecord }: { historyRecord: HistoryRecord; }) {
 	const { paladinInfo } = historyRecord;
 
-	const isCritical = GetIsCritical(historyRecord);
 	const totalWeaponDamage = GetTotalWeaponDamage(historyRecord);
 	const totalDivineSmiteDamage = GetTotalDivineSmiteDamage(historyRecord);
 
@@ -31,10 +30,7 @@ export default function AttackHistoryDetails({ historyRecord }: { historyRecord:
 				<Label>To Hit Rolls: {RollArrayToString(historyRecord.attackRolls)}</Label>
 			</li>
 			<li>
-				<Label>Critical Hit: <Checkbox disabled checked={isCritical} /></Label>
-			</li>
-			<li>
-				<Label>Was Hit: <Checkbox disabled checked={historyRecord.isHit} /></Label>
+				<Label>{GetHitStatusText(historyRecord)}</Label>
 			</li>
 		</Fragment>
 	);

--- a/src/pages/paladin/AttackSheet/Steps/PostAttackRollStep.tsx
+++ b/src/pages/paladin/AttackSheet/Steps/PostAttackRollStep.tsx
@@ -1,6 +1,5 @@
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { SheetHeader, SheetTitle, SheetDescription, SheetFooter } from "@/components/ui/sheet";
 import { PaladinAttackSheetState } from "../../PaladinTypes";
@@ -35,7 +34,9 @@ export default function PostAttackRollStep({ state, dispatch }: PostAttackRollSt
 				</SheetDescription>
 			</SheetHeader>
 			<div className="grid flex-1 auto-rows-min gap-6 px-4">
-				<Label>Critical Hit: <Checkbox disabled checked={isCritical} /></Label>
+				{isCritical && (
+					<Label>Critical Hit</Label>
+				)}
 				<Card>
 					<h2 className={`text-center ${hitValueTextColorClass}`}>
 						{isCritical && <strong>{highestAttackValue}</strong>}


### PR DESCRIPTION
## Summary
- `PostAttackRollStep.tsx`: "Critical Hit" is now a plain label shown only when the roll is actually a crit, instead of an always-visible checkbox.
- `AttackHistoryDetails.tsx` (Paladin): the separate "Critical Hit"/"Was Hit" checkbox lines are combined into a single hit-status text line via the existing `GetHitStatusText` helper.

## Justification
Matches the equivalent Gloomstalker components (`PostHitRollStep.tsx`, `AttackHistoryDetails.tsx`), which use this same conditional-label / combined-text pattern instead of disabled checkboxes for hit/crit status.

Presentation-only — no game logic, state, or command changes.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run test`
- [x] Independent code review of the commit (clean, no findings)
- [ ] Manual check in a running app: confirm the "Critical Hit" label only appears on a natural 20 in the attack sheet, and the expanded history detail view shows a single combined hit-status line

🤖 Generated with [Claude Code](https://claude.com/claude-code)