### PR TITLE
Give each Paladin attack-sheet step a distinct title/description

### DIFF
--- a/src/pages/paladin/AttackSheet/Steps/PostAttackRollStep.tsx
+++ b/src/pages/paladin/AttackSheet/Steps/PostAttackRollStep.tsx
@@ -29,7 +29,7 @@ export default function PostAttackRollStep({ state, dispatch }: PostAttackRollSt
 	return (
 		<>
 			<SheetHeader>
-				<SheetTitle>Roll for Attack</SheetTitle>
+				<SheetTitle>Post Attack Roll</SheetTitle>
 				<SheetDescription>
 					Did Attack Hit?
 				</SheetDescription>

--- a/src/pages/paladin/AttackSheet/Steps/PreAttackRollStep.tsx
+++ b/src/pages/paladin/AttackSheet/Steps/PreAttackRollStep.tsx
@@ -24,7 +24,7 @@ export default function PreAttackRollStep({ state, dispatch }: PreAttackRollStep
 			<SheetHeader>
 				<SheetTitle>Roll for Attack</SheetTitle>
 				<SheetDescription>
-					Provide Attack Information, roll for attack, provide damage information, and then roll for damage.
+					Provide pre-attack-roll information and roll for attack
 				</SheetDescription>
 			</SheetHeader>
 			<div className="grid flex-1 auto-rows-min gap-6 px-4">

--- a/src/pages/paladin/AttackSheet/Steps/PreDamageRollStep.tsx
+++ b/src/pages/paladin/AttackSheet/Steps/PreDamageRollStep.tsx
@@ -31,9 +31,9 @@ export default function PreDamageRollStep({ state, dispatch }: PreDamageRollStep
 	return (
 		<>
 			<SheetHeader>
-				<SheetTitle>Damage Info</SheetTitle>
+				<SheetTitle>Pre Damage Roll</SheetTitle>
 				<SheetDescription>
-					Provide Additional Damage Information
+					Provide Additional Damage Information before rolling for damage
 				</SheetDescription>
 			</SheetHeader>
 			<div className="grid flex-1 auto-rows-min gap-6 px-4">


### PR DESCRIPTION
## Summary

- Gives each step in the Paladin attack sheet (`PreAttackRollStep`, `PostAttackRollStep`, `PreDamageRollStep`) a distinct, step-scoped `SheetTitle`/`SheetDescription`, matching the Gloomstalker attack sheet's existing convention.
- `PreAttackRollStep`: description changed to "Provide pre-attack-roll information and roll for attack" (title unchanged: "Roll for Attack").
- `PostAttackRollStep`: title changed to "Post Attack Roll" (was "Roll for Attack", duplicating the pre-roll step's title; description unchanged: "Did Attack Hit?").
- `PreDamageRollStep`: title changed to "Pre Damage Roll" (was "Damage Info"), description changed to "Provide Additional Damage Information before rolling for damage" (was "Provide Additional Damage Information").
- `ResultsStep.tsx` intentionally left unchanged — its title/description already matched Gloomstalker's exactly.

## Justification

Paladin previously reused "Roll for Attack" as the title for two different steps (`PreAttackRollStep` and `PostAttackRollStep`), and the first step's description carried a full-flow summary instead of a terse, step-scoped one. This made the two steps hard to visually distinguish and diverged from the Gloomstalker attack sheet, where every step already has its own distinct title and description. Wording is adapted to Paladin's own "attack roll" terminology (never "hit roll") and does not carry over an existing typo ("Damgage") present in Gloomstalker's equivalent copy.

This is a pure text/JSX change — no props, state, or logic touched.

## Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — passes (0 errors; 4 pre-existing warnings in unrelated shadcn UI files)
- [x] `npm run test` — passes (105/105 tests)
- [x] Independent review via the `code-review` skill against `development..HEAD` — zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>