### PR TITLE
Align Paladin checkbox/label pairs with Gloomstalker styling

### DIFF
--- a/src/pages/paladin/AttackSheet/Steps/PreAttackRollStep.tsx
+++ b/src/pages/paladin/AttackSheet/Steps/PreAttackRollStep.tsx
@@ -29,8 +29,8 @@ export default function PreAttackRollStep({ state, dispatch }: PreAttackRollStep
 			</SheetHeader>
 			<div className="grid flex-1 auto-rows-min gap-6 px-4">
 				<div className="grid gap-3">
-					<Label htmlFor="hasAdvantage">
-						<Checkbox id="hasAdvantage" checked={hasAdvantage}
+					<Label htmlFor="hasAdvantage" className="flex items-center space-x-2">
+						<Checkbox id="hasAdvantage" className="flex items-center space-x-2" checked={hasAdvantage}
 							onCheckedChange={() => setHasAdvantage(!hasAdvantage)} />
 						Has Advantage?
 					</Label>

--- a/src/pages/paladin/AttackSheet/Steps/PreDamageRollStep.tsx
+++ b/src/pages/paladin/AttackSheet/Steps/PreDamageRollStep.tsx
@@ -38,8 +38,8 @@ export default function PreDamageRollStep({ state, dispatch }: PreDamageRollStep
 			</SheetHeader>
 			<div className="grid flex-1 auto-rows-min gap-6 px-4">
 				<div className="grid gap-3" title="Adds 1d8 Radiant Damage on any attack against undead or fiends">
-					<Label htmlFor="isTargetFiendOrUndead">
-						<Checkbox id="isTargetFiendOrUndead" checked={isTargetFiendOrUndead}
+					<Label htmlFor="isTargetFiendOrUndead" className="flex items-center space-x-2">
+						<Checkbox id="isTargetFiendOrUndead" className="flex items-center space-x-2" checked={isTargetFiendOrUndead}
 							onCheckedChange={() => setIsTargetFiendOrUndead(!isTargetFiendOrUndead)} />
 						Is Target Fiend or Undead?
 					</Label>

--- a/src/pages/paladin/PaladinInfoTab.tsx
+++ b/src/pages/paladin/PaladinInfoTab.tsx
@@ -59,8 +59,8 @@ export default function PaladinInfoTab({ paladinInfo, onChange, addToRollHistory
 					}
 				/>
 				<div title="Automaticlly adds 1d8 Radiant Damage on any attack">
-					<Label htmlFor="hasImprovedDS">
-						<Checkbox id="hasImprovedDS" checked={hasImprovedDS}
+					<Label htmlFor="hasImprovedDS" className="flex items-center space-x-2">
+						<Checkbox id="hasImprovedDS" className="flex items-center space-x-2" checked={hasImprovedDS}
 							onCheckedChange={() => setHasImprovedDS(!hasImprovedDS)} />
 						Has Improved Divine Smite?
 					</Label>


### PR DESCRIPTION
## Summary
- Adds `className="flex items-center space-x-2"` to the `Label` and nested `Checkbox` in three Paladin checkbox/label pairs:
  - `src/pages/paladin/PaladinInfoTab.tsx` — "Has Improved Divine Smite?"
  - `src/pages/paladin/AttackSheet/Steps/PreAttackRollStep.tsx` — "Has Advantage?"
  - `src/pages/paladin/AttackSheet/Steps/PreDamageRollStep.tsx` — "Is Target Fiend or Undead?"
- Purely additive styling change — no state, logic, or behavior change.

## Justification
Part of an ongoing pass to bring the Paladin character page's UI in line with the Gloomstalker page's UI. Gloomstalker's `PreDamageRollStep.tsx` already applies this horizontal flex-alignment class to its checkbox/label pairs; Paladin's equivalent pairs didn't have it. This change ports that exact, already-shipped pattern verbatim so the two pages render consistently.

Note: an independent review flagged that this class combination stacks with `Label`'s own built-in `gap-2` (from `src/components/ui/label.tsx`), which is a pre-existing quirk already present in Gloomstalker's shipped code today — not something newly introduced here. Since the goal is visual parity with Gloomstalker specifically (not an independent "ideal" spacing), replicating the exact reference pattern was the correct scope for this change. Any real fix to that underlying quirk would need to touch both character pages together and is left as a separate follow-up.

## Test plan
- [x] `npm run build` — passes (tsc + vite build clean)
- [x] `npm run lint` — passes (0 errors; 4 pre-existing warnings in unrelated files)
- [x] `npm run test` — 105/105 tests pass
- [x] Manual diff review — confirmed only the three intended className additions, no other changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)