### PR TITLE
Fix Gloomstalker damage step title/typo and dead branch

### DIFF
--- a/src/pages/gloomstalker/AttackSheet/Steps/PostDamageRollStep.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Steps/PostDamageRollStep.tsx
@@ -44,7 +44,7 @@ export default function PostDamageRollStep({ state, dispatch }: PostDamageRollSt
 	return (
 		<>
 			<SheetHeader>
-				<SheetTitle>Post Hit Roll</SheetTitle>
+				<SheetTitle>Post Damage Roll</SheetTitle>
 				<SheetDescription>
 					Apply any additional damage modifiers and confirm final damage rolls
 				</SheetDescription>

--- a/src/pages/gloomstalker/AttackSheet/Steps/PostDamageRollStep.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Steps/PostDamageRollStep.tsx
@@ -31,15 +31,11 @@ export default function PostDamageRollStep({ state, dispatch }: PostDamageRollSt
 
 	const bestRerollOption = GetBestRerollOption(state);
 	const alreadyBestRolls = bestRerollOption === null;
-	let rerollButtonText = bestRerollOption
-		? `Reroll Lowest Damage Roll? (d${bestRerollOption.dieSize}->${bestRerollOption.roll})`
-		: "Already best rolls!";
-
-	if (state.hasUsedReroll) {
-		rerollButtonText = "Reroll Used";
-	} else if (alreadyBestRolls) {
-		rerollButtonText = "Already best rolls!";
-	}
+	const rerollButtonText = state.hasUsedReroll
+		? "Reroll Used"
+		: bestRerollOption
+			? `Reroll Lowest Damage Roll? (d${bestRerollOption.dieSize}->${bestRerollOption.roll})`
+			: "Already best rolls!";
 
 	return (
 		<>

--- a/src/pages/gloomstalker/AttackSheet/Steps/PreDamageRollStep.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Steps/PreDamageRollStep.tsx
@@ -27,7 +27,7 @@ export default function PreDamageRollStep({ state, dispatch }: PreDamageRollStep
 	return (
 		<>
 			<SheetHeader>
-				<SheetTitle>Pre Damgage Roll</SheetTitle>
+				<SheetTitle>Pre Damage Roll</SheetTitle>
 				<SheetDescription>
 					Provide Additional Damage Information before rolling for damage
 				</SheetDescription>


### PR DESCRIPTION
## Summary
- `PostDamageRollStep.tsx`: fix the sheet title, which incorrectly read "Post Hit Roll" instead of "Post Damage Roll".
- `PreDamageRollStep.tsx`: fix a typo in the sheet title, "Pre Damgage Roll" -> "Pre Damage Roll".
- `PostDamageRollStep.tsx`: simplify the `rerollButtonText` logic by collapsing an unreachable `else if` branch into a single `const` ternary (no behavior change).

## Justification
Both Gloomstalker damage steps were forked from the Paladin page's equivalent steps, and these two string leftovers slipped through: the post-damage step was still announcing itself with the pre-fork "Post Hit Roll" title, and the pre-damage step carried a "Damgage" typo that doesn't exist in the Paladin original. Both are directly user-visible in the attack sheet UI.

Separately, the `rerollButtonText` computation had a dead `else if (alreadyBestRolls)` branch: `alreadyBestRolls` is true exactly when `bestRerollOption` is `null`, and in that case the initial ternary had already produced the same `"Already best rolls!"` string, so the branch could never actually change the value. Collapsed to one `const` ternary covering the same truth table; `alreadyBestRolls` is retained since it's still used by the reroll button's `disabled` prop.

## Future work
None — this is a self-contained cleanup of copy-paste leftovers in two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)