### PR TITLE
Fix: harden LocalStorage against corrupt stored values

### DIFF
--- a/src/utils/LocalStorage.test.tsx
+++ b/src/utils/LocalStorage.test.tsx
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { GetLocalStorage, ILocalStorageItem, SaveLocalStorage } from './LocalStorage';
+
+interface TestItem extends ILocalStorageItem {
+	nested: { count: number };
+	list: number[];
+}
+
+const storageKey = 'test-storage';
+const storageVersion = '1.0';
+const defaultItem: TestItem = {
+	nested: { count: 0 },
+	list: [],
+};
+
+beforeEach(() => {
+	localStorage.clear();
+});
+
+describe('GetLocalStorage', () => {
+	it('round-trips a saved item', () => {
+		const item: TestItem = { nested: { count: 5 }, list: [1, 2, 3] };
+		SaveLocalStorage(storageKey, storageVersion, item);
+
+		const result = GetLocalStorage<TestItem>(storageKey, storageVersion, defaultItem);
+
+		expect(result).toEqual({ ...item, storageVersion });
+	});
+
+	it('falls back to the default item on a storage version mismatch', () => {
+		SaveLocalStorage<TestItem>(storageKey, '0.9', { nested: { count: 5 }, list: [1, 2, 3] });
+
+		const result = GetLocalStorage<TestItem>(storageKey, storageVersion, defaultItem);
+
+		expect(result).toEqual({ ...defaultItem, storageVersion });
+	});
+
+	it('falls back to the default item instead of throwing on a corrupt/non-JSON value', () => {
+		localStorage.setItem(storageKey, 'not valid json {{{');
+
+		expect(() => GetLocalStorage<TestItem>(storageKey, storageVersion, defaultItem)).not.toThrow();
+		expect(GetLocalStorage<TestItem>(storageKey, storageVersion, defaultItem)).toEqual({ ...defaultItem, storageVersion });
+	});
+
+	it('falls back to the default item when "null" is stored under the key', () => {
+		localStorage.setItem(storageKey, 'null');
+
+		const result = GetLocalStorage<TestItem>(storageKey, storageVersion, defaultItem);
+
+		expect(result).toEqual({ ...defaultItem, storageVersion });
+	});
+
+	it('does not share nested object/array references across separate default fallbacks', () => {
+		const first = GetLocalStorage<TestItem>(storageKey, storageVersion, defaultItem);
+		const second = GetLocalStorage<TestItem>(storageKey, storageVersion, defaultItem);
+
+		expect(first.nested).not.toBe(second.nested);
+		expect(first.list).not.toBe(second.list);
+		expect(first.nested).not.toBe(defaultItem.nested);
+		expect(first.list).not.toBe(defaultItem.list);
+	});
+});
+
+describe('SaveLocalStorage', () => {
+	it('does not mutate the object it was handed', () => {
+		const item: TestItem = { nested: { count: 1 }, list: [1] };
+
+		SaveLocalStorage(storageKey, storageVersion, item);
+
+		expect(item).toEqual({ nested: { count: 1 }, list: [1] });
+		expect(item.storageVersion).toBeUndefined();
+	});
+});

--- a/src/utils/LocalStorage.tsx
+++ b/src/utils/LocalStorage.tsx
@@ -8,16 +8,20 @@ export function GetLocalStorage<T extends ILocalStorageItem>(storageKey: string,
 
 	// if we found a value
 	if (savedStorageStr) {
-		const savedStorage = JSON.parse(savedStorageStr);
+		try {
+			const savedStorage = JSON.parse(savedStorageStr);
 
-		// and if the storage matches the schema version we expect
-		if (savedStorage.storageVersion === storageVersion) {
-			return savedStorage;
+			// and if the storage matches the schema version we expect
+			if (savedStorage && typeof savedStorage === 'object' && savedStorage.storageVersion === storageVersion) {
+				return savedStorage;
+			}
+		} catch {
+			// corrupt/non-JSON value under this key; fall through to default
 		}
 	}
 
-	// return copy of default, with storage version added
-	return { ...defaultItem, storageVersion } as T;
+	// return deep copy of default, with storage version added
+	return { ...structuredClone(defaultItem), storageVersion } as T;
 }
 
 export function SaveLocalStorage<T extends ILocalStorageItem>(storageKey: string, storageVersion: string, localStorageItem: T) {

--- a/src/utils/LocalStorage.tsx
+++ b/src/utils/LocalStorage.tsx
@@ -25,6 +25,5 @@ export function GetLocalStorage<T extends ILocalStorageItem>(storageKey: string,
 }
 
 export function SaveLocalStorage<T extends ILocalStorageItem>(storageKey: string, storageVersion: string, localStorageItem: T) {
-	localStorageItem.storageVersion = storageVersion;
-	localStorage.setItem(storageKey, JSON.stringify(localStorageItem));
+	localStorage.setItem(storageKey, JSON.stringify({ ...localStorageItem, storageVersion }));
 }


### PR DESCRIPTION
## Summary
- `GetLocalStorage` now wraps `JSON.parse` in a try/catch and guards against parsed results that aren't a non-null object before reading `storageVersion`, falling back to the default item in either case instead of throwing.
- The default-item fallback now returns a `structuredClone` of `defaultItem` rather than a shallow spread, so callers no longer share nested object/array references with the module-level default literal.
- `SaveLocalStorage` no longer mutates the object it's handed — it serializes a spread copy with `storageVersion` applied instead of assigning onto the caller's object.
- Adds `src/utils/LocalStorage.test.tsx` covering: round-trip, version-mismatch fallback, corrupt/non-JSON value fallback (the crash regression test), `"null"`-stored fallback, `SaveLocalStorage` non-mutation, and that separate default fallbacks don't share nested references.

## Justification
`GetLocalStorage` is called from `GetLocalPaladinStorage`/`GetLocalGloomStalkerStorage` inside `useState` initializers on both character pages. Any non-JSON (or non-object JSON, e.g. `"null"`) value ever written under those `localStorage` keys — by a browser extension, manual tampering, or a future bug — throws during the initializer and escapes into render, permanently white-screening the page. The user can't even reach the "Clear Rolls" button to recover, since the UI never mounts. The other two fixes (shared default references, argument mutation) were latent-but-real traps in the same function that were cheap to remove alongside the crash fix.

Public signatures of `GetLocalStorage`/`SaveLocalStorage` are unchanged; only `src/utils/LocalStorage.tsx` and the new test file are touched.

## Future work
None anticipated — this closes out the known defects in the generic storage util. If a future caller needs partial/best-effort recovery from a corrupt-but-parseable value (rather than falling back to the full default), that would be a separate, deliberate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)