### PR TITLE
Move Gloomstalker damage/to-hit totals into AttackSheetStateFunctions

### DIFF
--- a/src/pages/gloomstalker/AttackHistoryDetails.tsx
+++ b/src/pages/gloomstalker/AttackHistoryDetails.tsx
@@ -1,6 +1,16 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
-import { GetHighestHitRoll, GetCritStatus, GetFavoredEnemyBonus, GetHitStatusText } from "./AttackSheet/AttackSheetStateFunctions";
+import {
+	GetHighestHitRoll,
+	GetHighestHitValue,
+	GetCritStatus,
+	GetFavoredEnemyBonus,
+	GetHitStatusText,
+	GetTotalDamage,
+	GetTotalFireDamage,
+	GetTotalForceDamage,
+	GetTotalPiercingDamage,
+} from "./AttackSheet/AttackSheetStateFunctions";
 import { HistoryRecord, CritStatus } from "./GloomStalkerTypes";
 import { Fragment } from "react";
 import { JoinWithElement, RollArrayToString } from "@/utils/Formatting";
@@ -12,13 +22,10 @@ export default function AttackHistoryDetails({ historyRecord }: { historyRecord:
 
 	const hitStatus = GetCritStatus(historyRecord);
 	const favoredEnemyBonus = GetFavoredEnemyBonus(historyRecord);
-	const totalPiercingDamage = historyRecord.piercingDamageRolls.reduce((a, value) => a + value, 0)
-		+ gloomStalkerInfo.damageModifier
-		+ (historyRecord.applySharpShooterPenalty ? 10 : 0)
-		+ favoredEnemyBonus;
-	const totalFireDamage = historyRecord.fireDamageRolls.reduce((a, value) => a + value, 0);
-	const totalForceDamage = historyRecord.forceDamageRolls.reduce((a, value) => a + value, 0);
-	const totalDamage = totalPiercingDamage + totalFireDamage + totalForceDamage;
+	const totalPiercingDamage = GetTotalPiercingDamage(historyRecord);
+	const totalFireDamage = GetTotalFireDamage(historyRecord);
+	const totalForceDamage = GetTotalForceDamage(historyRecord);
+	const totalDamage = GetTotalDamage(historyRecord);
 
 	const damageSummary = (
 		<Fragment key="damageSummary">
@@ -51,7 +58,7 @@ export default function AttackHistoryDetails({ historyRecord }: { historyRecord:
 	);
 
 	const highestHitRoll = GetHighestHitRoll(historyRecord);
-	const totalHitValue = highestHitRoll + gloomStalkerInfo.attackModifier + (historyRecord.applySharpShooterPenalty ? -5 : 0) + favoredEnemyBonus;
+	const totalHitValue = GetHighestHitValue(historyRecord);
 
 	const toHitSummary = (
 		<Fragment key="toHitSummary">

--- a/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.test.tsx
+++ b/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.test.tsx
@@ -12,6 +12,10 @@ import {
 	GetHitStatusColorClass,
 	GetHitStatusText,
 	GetPiercingDamageDicePool,
+	GetTotalDamage,
+	GetTotalFireDamage,
+	GetTotalForceDamage,
+	GetTotalPiercingDamage,
 	RollHitDice,
 } from './AttackSheetStateFunctions';
 import { CritStatus, DamageType } from '../GloomStalkerTypes';
@@ -131,6 +135,84 @@ describe('GetFavoredEnemyBonus', () => {
 	it('returns +2 per selected favored enemy', () => {
 		const state = buildTestState({ selectedFavoredEnemies: ['Giant', 'Goblin'] });
 		expect(GetFavoredEnemyBonus(state)).toBe(4);
+	});
+});
+
+describe('GetTotalPiercingDamage', () => {
+	it('sums the piercing damage rolls and adds the damage modifier', () => {
+		const state = buildTestState({ piercingDamageRolls: [4, 5] });
+		// 4 + 5 + damageModifier(3)
+		expect(GetTotalPiercingDamage(state)).toBe(12);
+	});
+
+	it('adds the Sharpshooter +10 bonus when the penalty is applied', () => {
+		const state = buildTestState({ piercingDamageRolls: [4], applySharpShooterPenalty: true });
+		// 4 + damageModifier(3) + sharpshooter(10)
+		expect(GetTotalPiercingDamage(state)).toBe(17);
+	});
+
+	it('adds +2 per selected favored enemy', () => {
+		const state = buildTestState({ piercingDamageRolls: [4], selectedFavoredEnemies: ['Giant', 'Goblin'] });
+		// 4 + damageModifier(3) + favoredEnemyBonus(4)
+		expect(GetTotalPiercingDamage(state)).toBe(11);
+	});
+
+	it('combines the damage modifier, Sharpshooter bonus, and favored enemy bonus together', () => {
+		const state = buildTestState({
+			piercingDamageRolls: [4, 5],
+			applySharpShooterPenalty: true,
+			selectedFavoredEnemies: ['Giant'],
+		});
+		// (4 + 5) + damageModifier(3) + sharpshooter(10) + favoredEnemyBonus(2)
+		expect(GetTotalPiercingDamage(state)).toBe(24);
+	});
+});
+
+describe('GetTotalFireDamage', () => {
+	it('sums the fire damage rolls', () => {
+		const state = buildTestState({ fireDamageRolls: [4, 5] });
+		expect(GetTotalFireDamage(state)).toBe(9);
+	});
+
+	it('is 0 when there are no fire damage rolls', () => {
+		const state = buildTestState({ fireDamageRolls: [] });
+		expect(GetTotalFireDamage(state)).toBe(0);
+	});
+});
+
+describe('GetTotalForceDamage', () => {
+	it('sums the force damage rolls', () => {
+		const state = buildTestState({ forceDamageRolls: [4, 5] });
+		expect(GetTotalForceDamage(state)).toBe(9);
+	});
+
+	it('is 0 when there are no force damage rolls', () => {
+		const state = buildTestState({ forceDamageRolls: [] });
+		expect(GetTotalForceDamage(state)).toBe(0);
+	});
+});
+
+describe('GetTotalDamage', () => {
+	it('sums piercing, fire, and force damage together', () => {
+		const state = buildTestState({
+			piercingDamageRolls: [4],
+			fireDamageRolls: [2],
+			forceDamageRolls: [1],
+		});
+		// piercing(4 + damageModifier(3)) + fire(2) + force(1)
+		expect(GetTotalDamage(state)).toBe(10);
+	});
+
+	it('includes the Sharpshooter and favored enemy bonuses via GetTotalPiercingDamage', () => {
+		const state = buildTestState({
+			piercingDamageRolls: [4],
+			applySharpShooterPenalty: true,
+			selectedFavoredEnemies: ['Giant'],
+			fireDamageRolls: [2],
+			forceDamageRolls: [1],
+		});
+		// piercing(4 + damageModifier(3) + sharpshooter(10) + favoredEnemyBonus(2)) + fire(2) + force(1)
+		expect(GetTotalDamage(state)).toBe(22);
 	});
 });
 

--- a/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.tsx
+++ b/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.tsx
@@ -128,6 +128,25 @@ export function GetHighestHitValue(state: GloomStalkerAttackSheetState): number 
 	return highestRoll + modifier;
 }
 
+export function GetTotalPiercingDamage(state: GloomStalkerAttackSheetState): number {
+	return state.piercingDamageRolls.reduce((a, value) => a + value, 0)
+		+ state.gloomStalkerInfo.damageModifier
+		+ (state.applySharpShooterPenalty ? 10 : 0)
+		+ GetFavoredEnemyBonus(state);
+}
+
+export function GetTotalFireDamage(state: GloomStalkerAttackSheetState): number {
+	return state.fireDamageRolls.reduce((a, value) => a + value, 0);
+}
+
+export function GetTotalForceDamage(state: GloomStalkerAttackSheetState): number {
+	return state.forceDamageRolls.reduce((a, value) => a + value, 0);
+}
+
+export function GetTotalDamage(state: GloomStalkerAttackSheetState): number {
+	return GetTotalPiercingDamage(state) + GetTotalFireDamage(state) + GetTotalForceDamage(state);
+}
+
 export function RollHitDice(hasAdvantage: boolean, rng: () => number = Math.random): number[] {
 	// elven accuracy allows you to roll an additional die when you have advantage, and pick the highest.
 	// effectively giving you one extra die to roll when you have advantage.


### PR DESCRIPTION
## Summary
- Adds four selectors to `src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.tsx` — `GetTotalPiercingDamage`, `GetTotalFireDamage`, `GetTotalForceDamage`, `GetTotalDamage` — mirroring the existing Paladin-side `GetTotalWeaponDamage`/`GetTotalDivineSmiteDamage`/`GetTotalDamage` shape.
- Rewrites `src/pages/gloomstalker/AttackHistoryDetails.tsx` to call these selectors (and the already-existing `GetHighestHitValue`) instead of hand-computing the same arithmetic inline in JSX.
- Adds unit test coverage for the four new selectors in `AttackSheetStateFunctions.test.tsx`, including the previously-untested Sharpshooter +10 damage bonus and favored-enemy damage bonus.

## Justification
The Gloomstalker attack sheet was the one place in the codebase where damage/to-hit math lived inside a React component's JSX rather than in the tested `AttackSheetStateFunctions` module that both character pages otherwise use for this. That meant the Sharpshooter +10 damage bonus and the favored-enemy damage bonus existed nowhere else and had zero test coverage, and the to-hit total in `AttackHistoryDetails.tsx` was a hand-copied duplicate of the already-tested `GetHighestHitValue`, free to silently drift from it over time. This change is strictly behavior-preserving — the arithmetic moved, it did not change — verified by comparing the old inline expressions term-by-term against the new selectors and by an independent code review of the commit range.

## Future work
None identified; this was a pure internal refactor with new test coverage, no follow-up work is implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)