### PR TITLE
chore: remove dead code and fix tests that cannot fail

### DIFF
--- a/src/pages/gloomstalker/AttackHistoryView.tsx
+++ b/src/pages/gloomstalker/AttackHistoryView.tsx
@@ -6,16 +6,15 @@ import AttackHistoryDetails from "./AttackHistoryDetails";
 import { GetHitStatusColorClass, GetHitStatusText } from "./AttackSheet/AttackSheetStateFunctions";
 
 interface AttackHistoryViewProps {
-	defaultOpen?: boolean;
 	historyRecord: HistoryRecord;
 }
 
-export default function AttackHistoryView({ defaultOpen, historyRecord }: AttackHistoryViewProps) {
+export default function AttackHistoryView({ historyRecord }: AttackHistoryViewProps) {
 	const hitText = GetHitStatusText(historyRecord);
 	const hitTextColorClass = GetHitStatusColorClass(historyRecord);
 
 	return (
-		<Collapsible defaultOpen={defaultOpen ?? false} className="group/collapsible">
+		<Collapsible className="group/collapsible">
 			<CollapsibleTrigger asChild className="w-full">
 				<Button variant="ghost">
 					<h3>

--- a/src/pages/gloomstalker/AttackSheet/Commands/AttackAgainCommand.test.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Commands/AttackAgainCommand.test.tsx
@@ -1,21 +1,21 @@
 import { describe, expect, it } from 'vitest';
 import { AttackStep } from '../../GloomStalkerTypes';
-import { GloomStalkerAttackSheetStateDefault } from '../AttackSheetStateFunctions';
 import { buildTestState, testGloomStalkerInfo } from '../test/fixtures';
 import AttackAgainCommand from './AttackAgainCommand';
 
 describe('AttackAgainCommand', () => {
-	it('resets to a fresh default state built from the previous gloomStalkerInfo', () => {
+	it('rebuilds default state from the gloomStalkerInfo carried on prevState', () => {
 		const state = buildTestState({
 			attackStep: AttackStep.Results,
 			attackRolls: [20],
 			isHit: true,
 			hasAdvantage: true,
+			gloomStalkerInfo: { ...testGloomStalkerInfo, attackModifier: 99 },
 		});
 
 		const result = new AttackAgainCommand().apply(state);
 
-		expect(result).toEqual(GloomStalkerAttackSheetStateDefault(testGloomStalkerInfo));
+		expect(result.gloomStalkerInfo.attackModifier).toBe(99);
 		expect(result.attackStep).toBe(AttackStep.PreHitRoll);
 	});
 });

--- a/src/pages/gloomstalker/AttackSheet/Commands/GoBackCommand.test.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Commands/GoBackCommand.test.tsx
@@ -48,4 +48,11 @@ describe('GoBackCommand', () => {
 
 		expect(result).toBe(state);
 	});
+
+	it('is a no-op from Results', () => {
+		const state = buildTestState({ attackStep: AttackStep.Results });
+		const result = new GoBackCommand().apply(state);
+
+		expect(result).toBe(state);
+	});
 });

--- a/src/pages/gloomstalker/AttackSheet/Commands/SetApplyHuntersMarkCommand.test.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Commands/SetApplyHuntersMarkCommand.test.tsx
@@ -7,5 +7,6 @@ describe('SetApplyHuntersMarkCommand', () => {
 		const state = buildTestState({ applyHuntersMark: false });
 
 		expect(new SetApplyHuntersMarkCommand(true).apply(state).applyHuntersMark).toBe(true);
+		expect(new SetApplyHuntersMarkCommand(false).apply(buildTestState({ applyHuntersMark: true })).applyHuntersMark).toBe(false);
 	});
 });

--- a/src/pages/gloomstalker/AttackSheet/Commands/SetApplySharpShooterPenaltyCommand.test.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Commands/SetApplySharpShooterPenaltyCommand.test.tsx
@@ -7,5 +7,6 @@ describe('SetApplySharpShooterPenaltyCommand', () => {
 		const state = buildTestState({ applySharpShooterPenalty: false });
 
 		expect(new SetApplySharpShooterPenaltyCommand(true).apply(state).applySharpShooterPenalty).toBe(true);
+		expect(new SetApplySharpShooterPenaltyCommand(false).apply(buildTestState({ applySharpShooterPenalty: true })).applySharpShooterPenalty).toBe(false);
 	});
 });

--- a/src/pages/gloomstalker/AttackSheet/Commands/SetIsDreadAmbusherExtraAttackCommand.test.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Commands/SetIsDreadAmbusherExtraAttackCommand.test.tsx
@@ -7,5 +7,6 @@ describe('SetIsDreadAmbusherExtraAttackCommand', () => {
 		const state = buildTestState({ isDreadAmbusherExtraAttack: false });
 
 		expect(new SetIsDreadAmbusherExtraAttackCommand(true).apply(state).isDreadAmbusherExtraAttack).toBe(true);
+		expect(new SetIsDreadAmbusherExtraAttackCommand(false).apply(buildTestState({ isDreadAmbusherExtraAttack: true })).isDreadAmbusherExtraAttack).toBe(false);
 	});
 });

--- a/src/pages/gloomstalker/GloomStalkerTypes.tsx
+++ b/src/pages/gloomstalker/GloomStalkerTypes.tsx
@@ -5,13 +5,6 @@ export interface GloomStalkerInfo {
 	favoredEnemies: string[];
 }
 
-export enum AttackState {
-	PreHitRoll,
-	PostHitRoll,
-	PreDamageRoll,
-	PostDamageRoll
-}
-
 export interface PreHitRollInfo {
 	hasAdvantage: boolean;
 	applySharpShooterPenalty: boolean;   // apply -5 to hit to get +10 damage?

--- a/src/pages/paladin/AttackHistoryView.tsx
+++ b/src/pages/paladin/AttackHistoryView.tsx
@@ -6,16 +6,15 @@ import { GetHitStatusColorClass, GetHitStatusText } from "./AttackSheet/AttackSh
 import AttackHistoryDetails from "./AttackHistoryDetails";
 
 interface AttackHistoryViewProps {
-	defaultOpen?: boolean;
 	historyRecord: HistoryRecord;
 }
 
-export default function AttackHistoryView({ defaultOpen, historyRecord }: AttackHistoryViewProps) {
+export default function AttackHistoryView({ historyRecord }: AttackHistoryViewProps) {
 	const hitText = GetHitStatusText(historyRecord);
 	const hitTextColorClass = GetHitStatusColorClass(historyRecord);
 
 	return (
-		<Collapsible defaultOpen={defaultOpen ?? false} className="group/collapsible">
+		<Collapsible className="group/collapsible">
 			<CollapsibleTrigger asChild className="w-full">
 				<Button variant="ghost">
 					<h3>

--- a/src/pages/paladin/AttackSheet/Commands/AttackAgainCommand.test.tsx
+++ b/src/pages/paladin/AttackSheet/Commands/AttackAgainCommand.test.tsx
@@ -1,21 +1,21 @@
 import { describe, expect, it } from 'vitest';
 import { AttackStep } from '../../PaladinTypes';
-import { PaladinAttackSheetStateDefault } from '../AttackSheetStateFunctions';
 import { buildTestState, testPaladinInfo } from '../test/fixtures';
 import AttackAgainCommand from './AttackAgainCommand';
 
 describe('AttackAgainCommand', () => {
-	it('resets to a fresh default state built from the previous paladinInfo', () => {
+	it('rebuilds default state from the paladinInfo carried on prevState', () => {
 		const state = buildTestState({
 			attackStep: AttackStep.Results,
 			attackRolls: [20],
 			isHit: true,
 			hasAdvantage: true,
+			paladinInfo: { ...testPaladinInfo, attackModifier: 99 },
 		});
 
 		const result = new AttackAgainCommand().apply(state);
 
-		expect(result).toEqual(PaladinAttackSheetStateDefault(testPaladinInfo));
+		expect(result.paladinInfo.attackModifier).toBe(99);
 		expect(result.attackStep).toBe(AttackStep.PreAttackRoll);
 	});
 });

--- a/src/pages/paladin/AttackSheet/Commands/ConfirmIsMissCommand.test.tsx
+++ b/src/pages/paladin/AttackSheet/Commands/ConfirmIsMissCommand.test.tsx
@@ -5,7 +5,7 @@ import ConfirmIsMissCommand from './ConfirmIsMissCommand';
 
 describe('ConfirmIsMissCommand', () => {
 	it('marks the attack as a miss and skips straight to Results', () => {
-		const state = buildTestState({ isHit: false, attackStep: AttackStep.PostAttackRoll });
+		const state = buildTestState({ isHit: true, attackStep: AttackStep.PostAttackRoll });
 		const result = new ConfirmIsMissCommand().apply(state);
 
 		expect(result.isHit).toBe(false);

--- a/src/pages/paladin/AttackSheet/Commands/GoBackCommand.test.tsx
+++ b/src/pages/paladin/AttackSheet/Commands/GoBackCommand.test.tsx
@@ -28,4 +28,11 @@ describe('GoBackCommand', () => {
 
 		expect(result).toBe(state);
 	});
+
+	it('is a no-op from Results', () => {
+		const state = buildTestState({ attackStep: AttackStep.Results });
+		const result = new GoBackCommand().apply(state);
+
+		expect(result).toBe(state);
+	});
 });


### PR DESCRIPTION
## Summary

- Removes the dead `AttackState` enum from `src/pages/gloomstalker/GloomStalkerTypes.tsx` — an abandoned first draft of the attack flow state machine, fully superseded by `AttackStep` (same members plus `Results`), with zero references anywhere in `src/`.
- Removes the unused `defaultOpen` prop from both `src/pages/paladin/AttackHistoryView.tsx` and `src/pages/gloomstalker/AttackHistoryView.tsx` — no caller ever passes it, and `Collapsible` already defaults to closed.
- Fixes several unit tests that could not fail even if the command under test were broken:
  - `ConfirmIsMissCommand.test.tsx` (Paladin) previously seeded `isHit: false` and asserted `isHit` is `false`, proving nothing. Now seeds `isHit: true` so the assertion proves the command actually flips it, matching the Gloomstalker twin.
  - `AttackAgainCommand.test.tsx` (both trees) previously asserted the result equals `*StateDefault(testXInfo)` using the same info object the fixture already carries, so it couldn't distinguish the real command (which rebuilds from `prevState`'s embedded info) from a buggy one that ignores `prevState` entirely. Now seeds a state whose embedded info differs from the fixture and asserts the result carries that differing value.
  - Three Gloomstalker boolean-setter command tests (`SetApplyHuntersMarkCommand`, `SetApplySharpShooterPenaltyCommand`, `SetIsDreadAmbusherExtraAttackCommand`) previously asserted only the `true` direction. Now assert both directions, matching `SetAdvantageCommand` and the Paladin setter tests.
  - `GoBackCommand.test.tsx` (both trees) previously only exercised the no-op `default:` branch from the very first step. Now also asserts it's a no-op from `AttackStep.Results` — the state where a stray Go Back would do the most damage.

## Justification

The Gloomstalker page was forked from the Paladin page, leaving behind dead code (`AttackState`, `defaultOpen`) that never got cleaned up. Separately, a review found several tests whose assertions restate the exact value they seeded or the exact expression the command evaluates — these pass unconditionally and give false confidence, since deleting or breaking the command's actual logic wouldn't turn them red. Both are cleaned up here since they're low-risk, mechanical fixes that reduce footguns (two near-identical enums, a plumbed-through prop nobody uses) and close real coverage gaps (tests that could not have caught the bugs they're nominally guarding against).

Each strengthened test was manually verified to fail against a deliberately broken version of its command before being finalized, then reverted — confirming it now actually pins behavior rather than restating the implementation.

## Future work

None identified — this is a self-contained cleanup pass. Two other test-hygiene items from the same review (a Gloomstalker `PostDamageRollStep.tsx` cleanup and a `rerollButtonText` cleanup) are owned by a separate concurrent workstream and are intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)