### PR TITLE
Align Paladin attack history details with Gloomstalker's

### DIFF
--- a/src/pages/gloomstalker/AttackHistoryDetails.tsx
+++ b/src/pages/gloomstalker/AttackHistoryDetails.tsx
@@ -13,9 +13,7 @@ import {
 } from "./AttackSheet/AttackSheetStateFunctions";
 import { HistoryRecord, CritStatus } from "./GloomStalkerTypes";
 import { Fragment } from "react";
-import { JoinWithElement, RollArrayToString } from "@/utils/Formatting";
-
-const diceArrayToString = (arr: number[]) => '[' + arr.map(die => `d${die}`).join(', ') + ']';
+import { DiceArrayToString, JoinWithElement, RollArrayToString } from "@/utils/Formatting";
 
 export default function AttackHistoryDetails({ historyRecord }: { historyRecord: HistoryRecord; }) {
 	const { gloomStalkerInfo } = historyRecord;
@@ -113,19 +111,19 @@ export default function AttackHistoryDetails({ historyRecord }: { historyRecord:
 				</li>
 			)}
 			<li>
-				<Label>Piercing Damage Dice: {diceArrayToString(historyRecord.piercingDamageDicePool)}</Label>
+				<Label>Piercing Damage Dice: {DiceArrayToString(historyRecord.piercingDamageDicePool)}</Label>
 			</li>
 			<li>
 				<Label>Piercing Damage Rolls: {RollArrayToString(historyRecord.piercingDamageRolls)}</Label>
 			</li>
 			<li>
-				<Label>Fire Damage Dice: {diceArrayToString(historyRecord.fireDamageDicePool)}</Label>
+				<Label>Fire Damage Dice: {DiceArrayToString(historyRecord.fireDamageDicePool)}</Label>
 			</li>
 			<li>
 				<Label>Fire Damage Rolls: {RollArrayToString(historyRecord.fireDamageRolls)}</Label>
 			</li>
 			<li>
-				<Label>Force Damage Dice: {diceArrayToString(historyRecord.forceDamageDicePool)}</Label>
+				<Label>Force Damage Dice: {DiceArrayToString(historyRecord.forceDamageDicePool)}</Label>
 			</li>
 			<li>
 				<Label>Force Damage Rolls: {RollArrayToString(historyRecord.forceDamageRolls)}</Label>

--- a/src/pages/paladin/AttackHistoryDetails.tsx
+++ b/src/pages/paladin/AttackHistoryDetails.tsx
@@ -1,67 +1,127 @@
 import { Card, CardContent } from "@/components/ui/card";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
-import { Fragment } from "react";
+import {
+	GetDivineSmiteDamageDicePool,
+	GetHighestAttackRoll,
+	GetHighestAttackValue,
+	GetHitStatusText,
+	GetIsCritical,
+	GetTotalDamage,
+	GetTotalDivineSmiteDamage,
+	GetTotalWeaponDamage,
+	GetWeaponDamageDicePool,
+	SpellSlotToString,
+} from "./AttackSheet/AttackSheetStateFunctions";
 import { HistoryRecord } from "./PaladinTypes";
-import { GetHitStatusText, GetTotalDivineSmiteDamage, GetTotalWeaponDamage, SpellSlotToString } from "./AttackSheet/AttackSheetStateFunctions";
-import { JoinWithElement, RollArrayToString } from "@/utils/Formatting";
+import { Fragment } from "react";
+import { DiceArrayToString, JoinWithElement, RollArrayToString } from "@/utils/Formatting";
 
 export default function AttackHistoryDetails({ historyRecord }: { historyRecord: HistoryRecord; }) {
 	const { paladinInfo } = historyRecord;
 
+	const isCritical = GetIsCritical(historyRecord);
 	const totalWeaponDamage = GetTotalWeaponDamage(historyRecord);
 	const totalDivineSmiteDamage = GetTotalDivineSmiteDamage(historyRecord);
+	const totalDamage = GetTotalDamage(historyRecord);
+
+	const damageSummary = (
+		<Fragment key="damageSummary">
+			<li>
+				<Label>Total Damage: {totalDamage}</Label>
+			</li>
+			<li>
+				<Label>Total Slashing Damage: {totalWeaponDamage}</Label>
+			</li>
+			<li>
+				<Label>Total Radiant Damage: {totalDivineSmiteDamage}</Label>
+			</li>
+		</Fragment>
+	);
 
 	const hitSummary = (
 		<Fragment key="hitSummary">
-			<li>
-				<Label>Attack Modifier: {paladinInfo.attackModifier}</Label>
-			</li>
-			<li>
-				<Label>Weapon Stats: d{paladinInfo.damageDie} + {paladinInfo.damageModifier}</Label>
-			</li>
-			<li>
-				<Label>Improved Divine Smite: <Checkbox disabled checked={paladinInfo.hasImprovedDS} /></Label>
-			</li>
-			<li>
-				<Label>Had Advantage: <Checkbox disabled checked={historyRecord.hasAdvantage} /></Label>
-			</li>
-			<li>
-				<Label>To Hit Rolls: {RollArrayToString(historyRecord.attackRolls)}</Label>
-			</li>
 			<li>
 				<Label>{GetHitStatusText(historyRecord)}</Label>
 			</li>
 		</Fragment>
 	);
 
-	const damageDetails = (
-		<Fragment key="damageDetails">
+	const highestHitRoll = GetHighestAttackRoll(historyRecord);
+	const totalHitValue = GetHighestAttackValue(historyRecord);
+
+	const toHitSummary = (
+		<Fragment key="toHitSummary">
 			<li>
-				<Label>Was Target Fiend or Undead: <Checkbox disabled checked={historyRecord.isTargetFiendOrUndead} /></Label>
+				<Label>Total Hit Value: {totalHitValue} ({highestHitRoll} + {paladinInfo.attackModifier})</Label>
+			</li>
+			{historyRecord.hasAdvantage && (
+				<li>
+					<Label>Advantage (Rolled 2d20)</Label>
+				</li>
+			)}
+			<li>
+				<Label>Hit Rolls: {RollArrayToString(historyRecord.attackRolls)}</Label>
 			</li>
 			<li>
-				<Label>Weapon Rolls: {RollArrayToString(historyRecord.weaponDamageRolls)}</Label>
+				<Label>Highest Hit Roll: {highestHitRoll}</Label>
 			</li>
 			<li>
-				<Label>Total Weapon Damage: {totalWeaponDamage}</Label>
-			</li>
-			<li>
-				<Label>Spell Slot Used: {SpellSlotToString(historyRecord.spellSlotUsed)}</Label>
-			</li>
-			<li>
-				<Label>Divine Smite Rolls: {RollArrayToString(historyRecord.divineSmiteDamageRolls)}</Label>
-			</li>
-			<li>
-				<Label>Total Divine Smite Damage: {totalDivineSmiteDamage}</Label>
+				<Label>Hit Modifier: +{paladinInfo.attackModifier}</Label>
 			</li>
 		</Fragment>
 	);
 
+	const damageRolls = (
+		<Fragment key="damageRolls">
+			<li>
+				<Label>Weapon Damage: d{paladinInfo.damageDie} + {paladinInfo.damageModifier} (Slashing)</Label>
+			</li>
+			{isCritical && (
+				<li>
+					<Label>Critical Hit doubled the damage dice</Label>
+				</li>
+			)}
+			{paladinInfo.hasImprovedDS && (
+				<li>
+					<Label>Improved Divine Smite added 1d8 Radiant</Label>
+				</li>
+			)}
+			{historyRecord.isTargetFiendOrUndead && (
+				<li>
+					<Label>Fiend or Undead target added 1d8 Radiant</Label>
+				</li>
+			)}
+			{historyRecord.spellSlotUsed > 0 && (
+				<li>
+					<Label>Level {SpellSlotToString(historyRecord.spellSlotUsed)} Spell Slot added {historyRecord.spellSlotUsed + 1}d8 Radiant</Label>
+				</li>
+			)}
+			<li>
+				<Label>Slashing Damage Dice: {DiceArrayToString(GetWeaponDamageDicePool(historyRecord))}</Label>
+			</li>
+			<li>
+				<Label>Slashing Damage Rolls: {RollArrayToString(historyRecord.weaponDamageRolls)}</Label>
+			</li>
+			<li>
+				<Label>Radiant Damage Dice: {DiceArrayToString(GetDivineSmiteDamageDicePool(historyRecord))}</Label>
+			</li>
+			<li>
+				<Label>Radiant Damage Rolls: {RollArrayToString(historyRecord.divineSmiteDamageRolls)}</Label>
+			</li>
+		</Fragment>
+	);
+
+	// Build the detail array in the order we want to display the details, and conditionally include details based on the history record properties
 	const detailArray = [hitSummary];
 
 	if (historyRecord.isHit) {
-		detailArray.push(damageDetails);
+		detailArray.push(damageSummary);
+	}
+
+	detailArray.push(toHitSummary);
+
+	if (historyRecord.isHit) {
+		detailArray.push(damageRolls);
 	}
 
 	return (

--- a/src/pages/paladin/AttackSheet/AttackSheetStateFunctions.test.tsx
+++ b/src/pages/paladin/AttackSheet/AttackSheetStateFunctions.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	CreateHistoryRecordFromState,
+	GetCritStatus,
 	GetDivineSmiteDamageDicePool,
 	GetHighestAttackRoll,
 	GetHighestAttackValue,
@@ -16,6 +17,7 @@ import {
 	SpellSlotToString,
 } from './AttackSheetStateFunctions';
 import { buildTestState, testPaladinInfo } from './test/fixtures';
+import { CritStatus } from '../PaladinTypes';
 
 describe('GetHighestAttackRoll / GetIsCritical', () => {
 	it('treats a 20 as a critical hit', () => {
@@ -30,6 +32,24 @@ describe('GetHighestAttackRoll / GetIsCritical', () => {
 	});
 });
 
+describe('GetCritStatus', () => {
+	it('reports a critical hit on a natural 20', () => {
+		expect(GetCritStatus(buildTestState({ attackRolls: [5, 20] }))).toBe(CritStatus.CriticalHit);
+	});
+
+	it('reports a critical miss on a natural 1', () => {
+		expect(GetCritStatus(buildTestState({ attackRolls: [1] }))).toBe(CritStatus.CriticalMiss);
+	});
+
+	it('reports Normal for anything in between', () => {
+		expect(GetCritStatus(buildTestState({ attackRolls: [10] }))).toBe(CritStatus.Normal);
+	});
+
+	it('only considers the highest roll, so advantage can rescue a 1', () => {
+		expect(GetCritStatus(buildTestState({ attackRolls: [1, 10] }))).toBe(CritStatus.Normal);
+	});
+});
+
 describe('GetHighestAttackValue', () => {
 	it('adds the attack modifier to the highest roll', () => {
 		const state = buildTestState({ attackRolls: [12] });
@@ -38,9 +58,9 @@ describe('GetHighestAttackValue', () => {
 });
 
 describe('GetHitStatusText', () => {
-	it('prefixes Critical only on a natural 20', () => {
+	it('prefixes Critical on a natural 20 and a natural 1', () => {
 		expect(GetHitStatusText(buildTestState({ attackRolls: [20], isHit: true }))).toBe('Critical Hit');
-		expect(GetHitStatusText(buildTestState({ attackRolls: [1], isHit: false }))).toBe('Miss');
+		expect(GetHitStatusText(buildTestState({ attackRolls: [1], isHit: false }))).toBe('Critical Miss');
 	});
 
 	it('reports plain Hit/Miss otherwise', () => {

--- a/src/pages/paladin/AttackSheet/AttackSheetStateFunctions.test.tsx
+++ b/src/pages/paladin/AttackSheet/AttackSheetStateFunctions.test.tsx
@@ -81,10 +81,14 @@ describe('GetHitStatusColorClass', () => {
 });
 
 describe('GetHitPreConfirmStatusColorClass', () => {
-	it('is blue on 20, green otherwise (no critical-miss concept)', () => {
+	it('is blue on 20, red on a critical miss, green otherwise', () => {
 		expect(GetHitPreConfirmStatusColorClass(buildTestState({ attackRolls: [20] }))).toBe('text-blue-500');
-		expect(GetHitPreConfirmStatusColorClass(buildTestState({ attackRolls: [1] }))).toBe('text-green-500');
+		expect(GetHitPreConfirmStatusColorClass(buildTestState({ attackRolls: [1] }))).toBe('text-red-500');
 		expect(GetHitPreConfirmStatusColorClass(buildTestState({ attackRolls: [10] }))).toBe('text-green-500');
+	});
+
+	it('ignores a 1 that advantage has already beaten', () => {
+		expect(GetHitPreConfirmStatusColorClass(buildTestState({ attackRolls: [1, 10] }))).toBe('text-green-500');
 	});
 });
 

--- a/src/pages/paladin/AttackSheet/AttackSheetStateFunctions.tsx
+++ b/src/pages/paladin/AttackSheet/AttackSheetStateFunctions.tsx
@@ -1,4 +1,4 @@
-import { AttackStep, HistoryRecord, PaladinAttackSheetState, PaladinInfo } from "../PaladinTypes";
+import { AttackStep, CritStatus, HistoryRecord, PaladinAttackSheetState, PaladinInfo } from "../PaladinTypes";
 import { RollDie } from "@/utils/Dice";
 
 export function PaladinAttackSheetStateDefault(paladinInfo: PaladinInfo): PaladinAttackSheetState {
@@ -27,8 +27,20 @@ export function GetHighestAttackRoll(state: PaladinAttackSheetState): number {
 	return Math.max(...state.attackRolls);
 }
 
+export function GetCritStatus(state: PaladinAttackSheetState): CritStatus {
+	const highestRoll = GetHighestAttackRoll(state);
+
+	if (highestRoll === 20) {
+		return CritStatus.CriticalHit;
+	}
+	if (highestRoll === 1) {
+		return CritStatus.CriticalMiss;
+	}
+	return CritStatus.Normal;
+}
+
 export function GetIsCritical(state: PaladinAttackSheetState): boolean {
-	return GetHighestAttackRoll(state) === 20;
+	return GetCritStatus(state) === CritStatus.CriticalHit;
 }
 
 export function GetHighestAttackValue(state: PaladinAttackSheetState): number {
@@ -36,7 +48,10 @@ export function GetHighestAttackValue(state: PaladinAttackSheetState): number {
 }
 
 export function GetHitStatusText(state: PaladinAttackSheetState): string {
-	return (GetIsCritical(state) ? 'Critical ' : '') + (state.isHit ? 'Hit' : 'Miss');
+	const critStatus = GetCritStatus(state);
+
+	const isCriticalHitOrMiss = critStatus !== CritStatus.Normal;
+	return (isCriticalHitOrMiss ? 'Critical ' : '') + (state.isHit ? 'Hit' : 'Miss');
 }
 
 export function GetHitStatusColorClass(state: PaladinAttackSheetState): string {

--- a/src/pages/paladin/AttackSheet/AttackSheetStateFunctions.tsx
+++ b/src/pages/paladin/AttackSheet/AttackSheetStateFunctions.tsx
@@ -67,7 +67,17 @@ export function GetHitStatusColorClass(state: PaladinAttackSheetState): string {
 }
 
 export function GetHitPreConfirmStatusColorClass(state: PaladinAttackSheetState): string {
-	return GetIsCritical(state) ? 'text-blue-500' : 'text-green-500';
+	const critStatus = GetCritStatus(state);
+
+	if (critStatus === CritStatus.CriticalHit) {
+		return 'text-blue-500';
+	}
+
+	if (critStatus === CritStatus.CriticalMiss) {
+		return 'text-red-500';
+	}
+
+	return 'text-green-500';
 }
 
 export function GetTotalWeaponDamage(state: PaladinAttackSheetState): number {

--- a/src/pages/paladin/AttackSheet/Steps/PostAttackRollStep.tsx
+++ b/src/pages/paladin/AttackSheet/Steps/PostAttackRollStep.tsx
@@ -2,8 +2,8 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { SheetHeader, SheetTitle, SheetDescription, SheetFooter } from "@/components/ui/sheet";
-import { PaladinAttackSheetState } from "../../PaladinTypes";
-import { GetHighestAttackValue, GetHitPreConfirmStatusColorClass, GetIsCritical } from "../AttackSheetStateFunctions";
+import { PaladinAttackSheetState, CritStatus } from "../../PaladinTypes";
+import { GetCritStatus, GetHighestAttackValue, GetHitPreConfirmStatusColorClass } from "../AttackSheetStateFunctions";
 import {
 	IPalAttackSheetCommand,
 	GoBackCommand,
@@ -21,7 +21,8 @@ export default function PostAttackRollStep({ state, dispatch }: PostAttackRollSt
 	const confirmIsMiss = () => dispatch(new ConfirmIsMissCommand());
 	const goBack = () => dispatch(new GoBackCommand());
 
-	const isCritical = GetIsCritical(state);
+	const critStatus = GetCritStatus(state);
+	const isCritical = critStatus === CritStatus.CriticalHit;
 	const hitValueTextColorClass = GetHitPreConfirmStatusColorClass(state);
 	const highestAttackValue = GetHighestAttackValue(state);
 
@@ -37,6 +38,9 @@ export default function PostAttackRollStep({ state, dispatch }: PostAttackRollSt
 				{isCritical && (
 					<Label>Critical Hit</Label>
 				)}
+				{critStatus === CritStatus.CriticalMiss && (
+					<Label>Critical Miss</Label>
+				)}
 				<Card>
 					<h2 className={`text-center ${hitValueTextColorClass}`}>
 						{isCritical && <strong>{highestAttackValue}</strong>}
@@ -45,8 +49,8 @@ export default function PostAttackRollStep({ state, dispatch }: PostAttackRollSt
 				</Card>
 			</div>
 			<SheetFooter>
-				<Button onClick={confirmIsHit}>Hit</Button>
-				<Button variant="secondary" onClick={confirmIsMiss}>Missed</Button>
+				<Button onClick={confirmIsHit} disabled={critStatus === CritStatus.CriticalMiss}>Hit</Button>
+				<Button variant="secondary" onClick={confirmIsMiss} disabled={isCritical}>Missed</Button>
 				<Button variant="outline" onClick={goBack}>Back</Button>
 			</SheetFooter>
 		</>

--- a/src/pages/paladin/PaladinTypes.tsx
+++ b/src/pages/paladin/PaladinTypes.tsx
@@ -39,3 +39,9 @@ export interface PaladinAttackSheetState extends PreAttackRollInfo, PostAttackRo
 export interface HistoryRecord extends PaladinAttackSheetState {
 	timestamp: number;
 }
+
+export enum CritStatus {
+	CriticalHit,
+	CriticalMiss,
+	Normal
+}

--- a/src/utils/Formatting.test.tsx
+++ b/src/utils/Formatting.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { JoinWithElement, RollArrayToString } from './Formatting';
+import { DiceArrayToString, JoinWithElement, RollArrayToString } from './Formatting';
 
 describe('RollArrayToString', () => {
 	it('formats an array of rolls as a bracketed, comma-separated list', () => {
@@ -8,6 +8,16 @@ describe('RollArrayToString', () => {
 
 	it('formats an empty array', () => {
 		expect(RollArrayToString([])).toBe('[]');
+	});
+});
+
+describe('DiceArrayToString', () => {
+	it('formats an array of die sizes as a bracketed, comma-separated list of dice', () => {
+		expect(DiceArrayToString([8, 8, 6])).toBe('[d8, d8, d6]');
+	});
+
+	it('formats an empty array', () => {
+		expect(DiceArrayToString([])).toBe('[]');
 	});
 });
 

--- a/src/utils/Formatting.tsx
+++ b/src/utils/Formatting.tsx
@@ -4,6 +4,10 @@ export function RollArrayToString(arr: number[]): string {
 	return '[' + arr.join(', ') + ']';
 }
 
+export function DiceArrayToString(arr: number[]): string {
+	return '[' + arr.map(die => `d${die}`).join(', ') + ']';
+}
+
 export function JoinWithElement(arr: JSX.Element[], element: JSX.Element): JSX.Element[] {
 	return arr.flatMap((item, index) =>
 		index < arr.length - 1 ? [item, cloneElement(element, { key: `separator-${index}` })] : [item]


### PR DESCRIPTION
## Summary

Makes a Paladin history entry read the way a Gloomstalker one does — same section order, same wording conventions, same level of detail — while respecting that the underlying game rules genuinely differ.

`src/pages/paladin/AttackHistoryDetails.tsx` is restructured into Gloomstalker's four sections in the same order (hit status → damage totals if hit → to-hit breakdown → damage dice/rolls if hit):

- Damage lines are named by **type** — Slashing for weapon damage, Radiant for Divine Smite — the way Gloomstalker names its Piercing/Fire/Force lines. Both names are hardcoded, as Gloomstalker hardcodes "Piercing".
- The Improved Divine Smite, fiend-or-undead and advantage **checkboxes become conditional notes** shown only when true, and the unconditional "Spell Slot Used: None" line becomes a conditional note naming the dice it contributed.
- Adds the previously missing **Total Damage** line, the **hit-value arithmetic**, and both **dice-pool** lines.

Two supporting changes came out of it:

- A natural 1 now reads **"Critical Miss"**, via a `CritStatus` enum and `GetCritStatus` selector mirroring Gloomstalker's. `GetIsCritical` deliberately keeps its natural-20-only meaning, since it drives damage-dice doubling, the Post Attack Roll banner, and the crit sound effect — none of which should fire on a natural 1.
- `diceArrayToString` is promoted out of the Gloomstalker component into a shared `DiceArrayToString` in `src/utils/Formatting.tsx`, now that both components need it.

## Justification

The two `AttackHistoryDetails` components had drifted. Gloomstalker leads with the outcome and shows its work; Paladin front-loaded static character stats, rendered booleans as disabled checkboxes so `false` values took up space, showed **no total-damage line at all** despite `GetTotalDamage` already existing, and showed neither the to-hit arithmetic nor the dice pools. The same card renders in two places — the live Results step and each expanded History row — so the gap was visible on every attack.

Teaching the Paladin about critical misses opened one contradictory state: roll a natural 1, confirm it as a Hit, and the header said "Critical Hit" while the dice were (correctly) not doubled. Rather than special-case the selector, this ports Gloomstalker's `disabled` guards from `PostHitRollStep` — Hit disabled on a critical miss, Missed disabled on a critical hit — so the state is unreachable and `GetHitStatusText` stays character-for-character equivalent to Gloomstalker's.

## Notes

- **No `storageVersion` bump.** Paladin doesn't persist dice pools, but `GetWeaponDamageDicePool` / `GetDivineSmiteDamageDicePool` derive them purely from a `PaladinAttackSheetState`, and `HistoryRecord extends PaladinAttackSheetState` — so previously-saved records render correctly untouched.
- Verified in the browser across critical hit, ordinary hit, miss, critical miss, and a level-4+ slot, plus a live roll through the sheet. Gloomstalker's card renders identically to before the helper extraction.
- `npm run lint` 0 errors (4 pre-existing shadcn warnings), `npm run test` 130/130, `npm run build` clean.

## Future work

- Gloomstalker's `GetHitStatusText` still open-codes its natural-20/natural-1 check instead of using its own `GetCritStatus`; Paladin's is now the cleaner of the two.
- Gloomstalker's `PostHitRollStep` has a "Critical Hit" label but no "Critical Miss" label — the Paladin sheet now has both.
- Neither `AttackHistoryDetails` has render tests; coverage is still pure-logic only, per the existing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)