### PR TITLE
Reuse GetCritStatus in Gloom Stalker's GetHitStatusText

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This is the web front end for The Grumbros website where we try our dumb stuff, 
 	- Done for the Paladin in PR #34, and already done for the Gloom Stalker apart from the label (see below).
 
 ## Follow-ups from the Paladin history-details parity work (PR #34)
-- Gloom Stalker's `GetHitStatusText` still open-codes `highest === 20 || highest === 1` instead of using its own `GetCritStatus` selector. The Paladin's is now the cleaner of the two.
 - The "can't confirm a Hit on a natural 1" rule lives only in the step component's `disabled` props. `ConfirmIsHitCommand` would still produce the contradictory state if dispatched directly, and any history record saved *before* PR #34 in that state renders as "Critical Hit" retroactively. Both characters share this; only changing `GetHitStatusText` would fix the stored records, at the cost of the two sheets no longer matching.
 - Neither character's `AttackHistoryDetails` has render tests — coverage is still pure-logic only (commands, selectors, reducers), even though React Testing Library is already installed.
 - Minor wording: the Paladin damage note reads "Level 4+ Spell Slot added 5d8 Radiant". "Level 4 or Higher Spell Slot" reads better. Kept as-is because `4` is a bucket, not an exact level — a bare "Level 4" would claim precision the app never captures.

--- a/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.tsx
+++ b/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.tsx
@@ -84,9 +84,7 @@ export function GetCritStatus(state: GloomStalkerAttackSheetState): CritStatus {
 }
 
 export function GetHitStatusText(state: GloomStalkerAttackSheetState): string {
-	const highestRoll = GetHighestHitRoll(state);
-
-	const isCriticalHitOrMiss = highestRoll === 20 || highestRoll === 1;
+	const isCriticalHitOrMiss = GetCritStatus(state) !== CritStatus.Normal;
 	return (isCriticalHitOrMiss ? 'Critical ' : '') + (state.isHit ? "Hit" : "Miss");
 }
 


### PR DESCRIPTION
## Summary
- `GetHitStatusText` in the Gloom Stalker's `AttackSheetStateFunctions.tsx` now derives crit status via the existing `GetCritStatus` selector instead of open-coding `highestRoll === 20 || highestRoll === 1`.

## Justification
- Matches the Paladin's `GetHitStatusText`, which already builds on `GetCritStatus`. This was the second follow-up item from PR #34's parity work — the Gloom Stalker was the only place still re-deriving crit status from raw roll values instead of reusing its own selector.
- Behavior is unchanged: `GetCritStatus(state) !== CritStatus.Normal` is equivalent to `highestRoll === 20 || highestRoll === 1`, and existing tests covering crit-hit/crit-miss/normal cases for `GetHitStatusText` still pass.

## Future work
- Remaining follow-ups from PR #34 (tracked in README.md): the `ConfirmIsHitCommand` contradictory-state gap, missing `AttackHistoryDetails` render tests, a wording nit on the Paladin damage note, and the `Math.max` empty-array edge case in `GetHighestAttackRoll`/`GetHighestHitRoll`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SSijTz5YNWonZmZ1kvG8iZ