### PR TITLE
Push attack-sheet UI logic into unit-tested pure functions

### DIFF
--- a/src/pages/gloomstalker/AttackHistoryDetails.tsx
+++ b/src/pages/gloomstalker/AttackHistoryDetails.tsx
@@ -1,10 +1,10 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import {
-	GetHighestHitRoll,
-	GetHighestHitValue,
+	FormatHitValueBreakdown,
 	GetCritStatus,
 	GetFavoredEnemyBonus,
+	GetHighestHitRoll,
 	GetHitStatusText,
 	GetTotalDamage,
 	GetTotalFireDamage,
@@ -12,8 +12,8 @@ import {
 	GetTotalPiercingDamage,
 } from "./AttackSheet/AttackSheetStateFunctions";
 import { HistoryRecord, CritStatus } from "./GloomStalkerTypes";
-import { Fragment } from "react";
-import { DiceArrayToString, JoinWithElement, RollArrayToString } from "@/utils/Formatting";
+import { Fragment, JSX } from "react";
+import { DetailSectionKey, DiceArrayToString, GetDetailSectionOrder, JoinWithElement, RollArrayToString } from "@/utils/Formatting";
 
 export default function AttackHistoryDetails({ historyRecord }: { historyRecord: HistoryRecord; }) {
 	const { gloomStalkerInfo } = historyRecord;
@@ -24,6 +24,7 @@ export default function AttackHistoryDetails({ historyRecord }: { historyRecord:
 	const totalFireDamage = GetTotalFireDamage(historyRecord);
 	const totalForceDamage = GetTotalForceDamage(historyRecord);
 	const totalDamage = GetTotalDamage(historyRecord);
+	const highestHitRoll = GetHighestHitRoll(historyRecord);
 
 	const damageSummary = (
 		<Fragment key="damageSummary">
@@ -55,13 +56,10 @@ export default function AttackHistoryDetails({ historyRecord }: { historyRecord:
 		</Fragment>
 	);
 
-	const highestHitRoll = GetHighestHitRoll(historyRecord);
-	const totalHitValue = GetHighestHitValue(historyRecord);
-
 	const toHitSummary = (
 		<Fragment key="toHitSummary">
 			<li>
-				<Label>Total Hit Value: {totalHitValue} ({highestHitRoll} + {gloomStalkerInfo.attackModifier}{historyRecord.applySharpShooterPenalty ? ' - 5' : ''}{favoredEnemyBonus > 0 ? ` + ${favoredEnemyBonus}` : ''})</Label>
+				<Label>Total Hit Value: {FormatHitValueBreakdown(historyRecord)}</Label>
 			</li>
 			{historyRecord.hasAdvantage && (
 				<li>
@@ -141,18 +139,14 @@ export default function AttackHistoryDetails({ historyRecord }: { historyRecord:
 		</Fragment>
 	);
 
-	// Build the detail array in the order we want to display the details, and conditionally include details based on the history record properties
-	const detailArray = [hitSummary];
+	const sectionsByKey: Record<DetailSectionKey, JSX.Element> = {
+		hitSummary,
+		damageSummary,
+		toHitSummary,
+		damageRolls,
+	};
 
-	if (historyRecord.isHit) {
-		detailArray.push(damageSummary);
-	}
-
-	detailArray.push(toHitSummary);
-
-	if (historyRecord.isHit) {
-		detailArray.push(damageRolls);
-	}
+	const detailArray = GetDetailSectionOrder(historyRecord.isHit).map(key => sectionsByKey[key]);
 
 	return (
 		<Card>

--- a/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.test.tsx
+++ b/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.test.tsx
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
 	CreateHistoryRecordFromState,
+	FormatDieRolls,
+	FormatHitValueBreakdown,
 	GetBestRerollOption,
 	GetCritStatus,
 	GetFireDamageDicePool,
@@ -11,7 +13,9 @@ import {
 	GetHitPreConfirmStatusColorClass,
 	GetHitStatusColorClass,
 	GetHitStatusText,
+	GetIsAlreadyBestRolls,
 	GetPiercingDamageDicePool,
+	GetRerollButtonText,
 	GetTotalDamage,
 	GetTotalFireDamage,
 	GetTotalForceDamage,
@@ -57,6 +61,48 @@ describe('GetBestRerollOption', () => {
 			type: DamageType.Piercing,
 			dicePoolIndex: 1,
 		});
+	});
+});
+
+describe('FormatDieRolls', () => {
+	it('zips rolls and dice into a d{size}->{roll} string', () => {
+		expect(FormatDieRolls([6, 3], [8, 8])).toBe('d8->6, d8->3');
+	});
+
+	it('formats an empty pool', () => {
+		expect(FormatDieRolls([], [])).toBe('');
+	});
+});
+
+describe('GetIsAlreadyBestRolls / GetRerollButtonText', () => {
+	it('reports "Reroll Used" once a reroll has been used', () => {
+		const state = buildTestState({
+			piercingDamageDicePool: [8],
+			piercingDamageRolls: [1],
+			hasUsedReroll: true,
+		});
+		expect(GetRerollButtonText(state)).toBe('Reroll Used');
+		expect(GetIsAlreadyBestRolls(state)).toBe(false);
+	});
+
+	it('offers the best rerollable die when one exists', () => {
+		const state = buildTestState({
+			piercingDamageDicePool: [8],
+			piercingDamageRolls: [1],
+			hasUsedReroll: false,
+		});
+		expect(GetRerollButtonText(state)).toBe('Reroll Lowest Damage Roll? (d8->1)');
+		expect(GetIsAlreadyBestRolls(state)).toBe(false);
+	});
+
+	it('reports "Already best rolls!" when every die is maxed', () => {
+		const state = buildTestState({
+			piercingDamageDicePool: [8],
+			piercingDamageRolls: [8],
+			hasUsedReroll: false,
+		});
+		expect(GetRerollButtonText(state)).toBe('Already best rolls!');
+		expect(GetIsAlreadyBestRolls(state)).toBe(true);
 	});
 });
 
@@ -135,6 +181,36 @@ describe('GetFavoredEnemyBonus', () => {
 	it('returns +2 per selected favored enemy', () => {
 		const state = buildTestState({ selectedFavoredEnemies: ['Giant', 'Goblin'] });
 		expect(GetFavoredEnemyBonus(state)).toBe(4);
+	});
+});
+
+describe('FormatHitValueBreakdown', () => {
+	it('formats a plain hit with no penalty or bonus', () => {
+		const state = buildTestState({ attackRolls: [12] });
+		// 12 + attackModifier(5) = 17
+		expect(FormatHitValueBreakdown(state)).toBe('17 (12 + 5)');
+	});
+
+	it('includes the sharpshooter penalty', () => {
+		const state = buildTestState({ attackRolls: [12], applySharpShooterPenalty: true });
+		// 12 + attackModifier(5) - 5 = 12
+		expect(FormatHitValueBreakdown(state)).toBe('12 (12 + 5 - 5)');
+	});
+
+	it('includes the favored enemy bonus', () => {
+		const state = buildTestState({ attackRolls: [12], selectedFavoredEnemies: ['Giant'] });
+		// 12 + attackModifier(5) + favoredEnemyBonus(2) = 19
+		expect(FormatHitValueBreakdown(state)).toBe('19 (12 + 5 + 2)');
+	});
+
+	it('combines the penalty and bonus together', () => {
+		const state = buildTestState({
+			attackRolls: [12],
+			applySharpShooterPenalty: true,
+			selectedFavoredEnemies: ['Giant'],
+		});
+		// 12 + attackModifier(5) - 5 + favoredEnemyBonus(2) = 14
+		expect(FormatHitValueBreakdown(state)).toBe('14 (12 + 5 - 5 + 2)');
 	});
 });
 

--- a/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.tsx
+++ b/src/pages/gloomstalker/AttackSheet/AttackSheetStateFunctions.tsx
@@ -120,6 +120,18 @@ export function GetFavoredEnemyBonus(state: GloomStalkerAttackSheetState): numbe
 	return state.selectedFavoredEnemies.length * 2;
 }
 
+export function FormatHitValueBreakdown(state: GloomStalkerAttackSheetState): string {
+	const highestHitRoll = GetHighestHitRoll(state);
+	const totalHitValue = GetHighestHitValue(state);
+	const favoredEnemyBonus = GetFavoredEnemyBonus(state);
+	const { attackModifier } = state.gloomStalkerInfo;
+
+	return `${totalHitValue} (${highestHitRoll} + ${attackModifier}`
+		+ (state.applySharpShooterPenalty ? ' - 5' : '')
+		+ (favoredEnemyBonus > 0 ? ` + ${favoredEnemyBonus}` : '')
+		+ ')';
+}
+
 export function GetHighestHitValue(state: GloomStalkerAttackSheetState): number {
 	const highestRoll = GetHighestHitRoll(state);
 	const modifier = state.gloomStalkerInfo.attackModifier + (state.applySharpShooterPenalty ? -5 : 0) + GetFavoredEnemyBonus(state);
@@ -201,6 +213,27 @@ export function GetFireDamageDicePool(state: GloomStalkerAttackSheetState): numb
 	}
 
 	return fireDamageDicePool;
+}
+
+export function FormatDieRolls(rolls: number[], dicePool: number[]): string {
+	return rolls.map((roll, index) => `d${dicePool[index]}->${roll}`).join(', ');
+}
+
+export function GetIsAlreadyBestRolls(state: GloomStalkerAttackSheetState): boolean {
+	return GetBestRerollOption(state) === null;
+}
+
+export function GetRerollButtonText(state: GloomStalkerAttackSheetState): string {
+	if (state.hasUsedReroll) {
+		return "Reroll Used";
+	}
+
+	const bestRerollOption = GetBestRerollOption(state);
+	if (bestRerollOption === null) {
+		return "Already best rolls!";
+	}
+
+	return `Reroll Lowest Damage Roll? (d${bestRerollOption.dieSize}->${bestRerollOption.roll})`;
 }
 
 export function GetForceDamageDicePool(state: GloomStalkerAttackSheetState): number[] {

--- a/src/pages/gloomstalker/AttackSheet/Steps/PostDamageRollStep.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Steps/PostDamageRollStep.tsx
@@ -3,7 +3,7 @@ import { SheetHeader, SheetTitle, SheetDescription, SheetFooter } from "@/compon
 import { Label } from "@/components/ui/label";
 import { JSX } from "react";
 import { GloomStalkerAttackSheetState } from '../../GloomStalkerTypes';
-import { GetBestRerollOption } from "../AttackSheetStateFunctions";
+import { FormatDieRolls, GetIsAlreadyBestRolls, GetRerollButtonText } from "../AttackSheetStateFunctions";
 import {
 	IGSAttackSheetCommand,
 	GoBackCommand,
@@ -25,17 +25,8 @@ export default function PostDamageRollStep({ state, dispatch }: PostDamageRollSt
 		rerollDamageDie();
 	};
 
-	const formatDieRolls = (rolls: number[], dicePool: number[]): string => {
-		return rolls.map((roll, index) => `d${dicePool[index]}->${roll}`).join(', ');
-	};
-
-	const bestRerollOption = GetBestRerollOption(state);
-	const alreadyBestRolls = bestRerollOption === null;
-	const rerollButtonText = state.hasUsedReroll
-		? "Reroll Used"
-		: bestRerollOption
-			? `Reroll Lowest Damage Roll? (d${bestRerollOption.dieSize}->${bestRerollOption.roll})`
-			: "Already best rolls!";
+	const alreadyBestRolls = GetIsAlreadyBestRolls(state);
+	const rerollButtonText = GetRerollButtonText(state);
 
 	return (
 		<>
@@ -46,9 +37,9 @@ export default function PostDamageRollStep({ state, dispatch }: PostDamageRollSt
 				</SheetDescription>
 			</SheetHeader>
 			<div className="grid flex-1 auto-rows-min gap-6 px-4">
-				<Label>Piercing Damage Rolls: [{formatDieRolls(state.piercingDamageRolls, state.piercingDamageDicePool)}]</Label>
-				<Label>Fire Damage Rolls: [{formatDieRolls(state.fireDamageRolls, state.fireDamageDicePool)}]</Label>
-				<Label>Force Damage Rolls: [{formatDieRolls(state.forceDamageRolls, state.forceDamageDicePool)}]</Label>
+				<Label>Piercing Damage Rolls: [{FormatDieRolls(state.piercingDamageRolls, state.piercingDamageDicePool)}]</Label>
+				<Label>Fire Damage Rolls: [{FormatDieRolls(state.fireDamageRolls, state.fireDamageDicePool)}]</Label>
+				<Label>Force Damage Rolls: [{FormatDieRolls(state.forceDamageRolls, state.forceDamageDicePool)}]</Label>
 				<Button onClick={handleReroll} disabled={state.hasUsedReroll || alreadyBestRolls}>
 					{rerollButtonText}
 				</Button>

--- a/src/pages/gloomstalker/AttackSheet/Steps/PostHitRollStep.tsx
+++ b/src/pages/gloomstalker/AttackSheet/Steps/PostHitRollStep.tsx
@@ -4,6 +4,7 @@ import { SheetHeader, SheetTitle, SheetDescription, SheetFooter } from "@/compon
 import { Label } from "@/components/ui/label";
 import { GloomStalkerAttackSheetState, CritStatus } from "../../GloomStalkerTypes";
 import { GetCritStatus, GetFavoredEnemyBonus, GetHighestHitValue, GetHitPreConfirmStatusColorClass } from "../AttackSheetStateFunctions";
+import { FormatSignedModifier } from "@/utils/Formatting";
 import {
 	IGSAttackSheetCommand,
 	GoBackCommand,
@@ -37,7 +38,7 @@ export default function PostHitRollStep({ state, dispatch }: PostHitRollStepProp
 			</SheetHeader>
 			<div className="grid flex-1 auto-rows-min gap-6 px-4">
 				<Label>To Hit Rolls: [{attackRolls.join(', ')}]</Label>
-				<Label>Attack Modifier: {attackModifier >= 0 ? `+${attackModifier}` : attackModifier}</Label>
+				<Label>Attack Modifier: {FormatSignedModifier(attackModifier)}</Label>
 				{state.applySharpShooterPenalty && <Label>Sharp Shooter Penalty: -5</Label>}
 				{state.selectedFavoredEnemies.length > 0 && (
 					<Label>Favored Enemy Bonus: +{GetFavoredEnemyBonus(state)} ({state.selectedFavoredEnemies.join(', ')})</Label>

--- a/src/pages/gloomstalker/FavoredEnemiesForm.tsx
+++ b/src/pages/gloomstalker/FavoredEnemiesForm.tsx
@@ -3,6 +3,7 @@ import { X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { AddFavoredEnemy, RemoveFavoredEnemy } from "./FavoredEnemiesFormFunctions";
 
 export interface FavoredEnemiesFormProps {
 	favoredEnemies: string[];
@@ -13,17 +14,15 @@ export default function FavoredEnemiesForm({ favoredEnemies, onChange }: Favored
 	const [newFavoredEnemy, setNewFavoredEnemy] = useState('');
 
 	const addFavoredEnemy = () => {
-		const trimmedName = newFavoredEnemy.trim();
-		if (trimmedName === '' || favoredEnemies.includes(trimmedName)) return;
-
-		// Dedupe defensively: a stale closure could otherwise let two rapid adds insert the same name twice,
-		// which would collide as a React key/id on the badge list below.
-		onChange(Array.from(new Set([...favoredEnemies, trimmedName])));
-		setNewFavoredEnemy('');
+		const result = AddFavoredEnemy(favoredEnemies, newFavoredEnemy);
+		if (result.added) {
+			onChange(result.favoredEnemies);
+			setNewFavoredEnemy('');
+		}
 	};
 
 	const removeFavoredEnemy = (name: string) => {
-		onChange(favoredEnemies.filter(favoredEnemy => favoredEnemy !== name));
+		onChange(RemoveFavoredEnemy(favoredEnemies, name));
 	};
 
 	return (

--- a/src/pages/gloomstalker/FavoredEnemiesFormFunctions.test.tsx
+++ b/src/pages/gloomstalker/FavoredEnemiesFormFunctions.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { AddFavoredEnemy, RemoveFavoredEnemy } from './FavoredEnemiesFormFunctions';
+
+describe('AddFavoredEnemy', () => {
+	it('adds a trimmed name to the list and reports added: true', () => {
+		expect(AddFavoredEnemy(['Giant'], '  Goblin  ')).toEqual({ favoredEnemies: ['Giant', 'Goblin'], added: true });
+	});
+
+	it('returns added: false and the list unchanged for an empty (or whitespace-only) name', () => {
+		expect(AddFavoredEnemy(['Giant'], '')).toEqual({ favoredEnemies: ['Giant'], added: false });
+		expect(AddFavoredEnemy(['Giant'], '   ')).toEqual({ favoredEnemies: ['Giant'], added: false });
+	});
+
+	it('returns added: false and the list unchanged for an exact duplicate', () => {
+		expect(AddFavoredEnemy(['Giant'], 'Giant')).toEqual({ favoredEnemies: ['Giant'], added: false });
+	});
+
+	it('rejects a duplicate after trimming', () => {
+		expect(AddFavoredEnemy(['Giant'], '  Giant  ')).toEqual({ favoredEnemies: ['Giant'], added: false });
+	});
+
+	it('adds to an empty list', () => {
+		expect(AddFavoredEnemy([], 'Giant')).toEqual({ favoredEnemies: ['Giant'], added: true });
+	});
+});
+
+describe('RemoveFavoredEnemy', () => {
+	it('removes an existing entry', () => {
+		expect(RemoveFavoredEnemy(['Giant', 'Goblin'], 'Giant')).toEqual(['Goblin']);
+	});
+
+	it('returns the list unchanged when the name is not present', () => {
+		expect(RemoveFavoredEnemy(['Giant'], 'Goblin')).toEqual(['Giant']);
+	});
+
+	it('returns an empty list when removing the only entry', () => {
+		expect(RemoveFavoredEnemy(['Giant'], 'Giant')).toEqual([]);
+	});
+});

--- a/src/pages/gloomstalker/FavoredEnemiesFormFunctions.tsx
+++ b/src/pages/gloomstalker/FavoredEnemiesFormFunctions.tsx
@@ -1,0 +1,19 @@
+export interface AddFavoredEnemyResult {
+	favoredEnemies: string[];
+	added: boolean;
+}
+
+export function AddFavoredEnemy(favoredEnemies: string[], name: string): AddFavoredEnemyResult {
+	const trimmedName = name.trim();
+	if (trimmedName === '' || favoredEnemies.includes(trimmedName)) {
+		return { favoredEnemies, added: false };
+	}
+
+	// Dedupe defensively: a stale closure could otherwise let two rapid adds insert the same name twice,
+	// which would collide as a React key/id on the badge list below.
+	return { favoredEnemies: Array.from(new Set([...favoredEnemies, trimmedName])), added: true };
+}
+
+export function RemoveFavoredEnemy(favoredEnemies: string[], name: string): string[] {
+	return favoredEnemies.filter(favoredEnemy => favoredEnemy !== name);
+}

--- a/src/pages/paladin/AttackHistoryDetails.tsx
+++ b/src/pages/paladin/AttackHistoryDetails.tsx
@@ -13,8 +13,8 @@ import {
 	SpellSlotToString,
 } from "./AttackSheet/AttackSheetStateFunctions";
 import { HistoryRecord } from "./PaladinTypes";
-import { Fragment } from "react";
-import { DiceArrayToString, JoinWithElement, RollArrayToString } from "@/utils/Formatting";
+import { Fragment, JSX } from "react";
+import { DetailSectionKey, DiceArrayToString, GetDetailSectionOrder, JoinWithElement, RollArrayToString } from "@/utils/Formatting";
 
 export default function AttackHistoryDetails({ historyRecord }: { historyRecord: HistoryRecord; }) {
 	const { paladinInfo } = historyRecord;
@@ -111,18 +111,14 @@ export default function AttackHistoryDetails({ historyRecord }: { historyRecord:
 		</Fragment>
 	);
 
-	// Build the detail array in the order we want to display the details, and conditionally include details based on the history record properties
-	const detailArray = [hitSummary];
+	const sectionsByKey: Record<DetailSectionKey, JSX.Element> = {
+		hitSummary,
+		damageSummary,
+		toHitSummary,
+		damageRolls,
+	};
 
-	if (historyRecord.isHit) {
-		detailArray.push(damageSummary);
-	}
-
-	detailArray.push(toHitSummary);
-
-	if (historyRecord.isHit) {
-		detailArray.push(damageRolls);
-	}
+	const detailArray = GetDetailSectionOrder(historyRecord.isHit).map(key => sectionsByKey[key]);
 
 	return (
 		<Card>

--- a/src/utils/Formatting.test.tsx
+++ b/src/utils/Formatting.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { DiceArrayToString, JoinWithElement, RollArrayToString } from './Formatting';
+import { DiceArrayToString, FormatSignedModifier, GetDetailSectionOrder, JoinWithElement, RollArrayToString } from './Formatting';
 
 describe('RollArrayToString', () => {
 	it('formats an array of rolls as a bracketed, comma-separated list', () => {
@@ -18,6 +18,30 @@ describe('DiceArrayToString', () => {
 
 	it('formats an empty array', () => {
 		expect(DiceArrayToString([])).toBe('[]');
+	});
+});
+
+describe('FormatSignedModifier', () => {
+	it('prefixes a positive modifier with +', () => {
+		expect(FormatSignedModifier(3)).toBe('+3');
+	});
+
+	it('prefixes zero with +', () => {
+		expect(FormatSignedModifier(0)).toBe('+0');
+	});
+
+	it('leaves a negative modifier as-is', () => {
+		expect(FormatSignedModifier(-2)).toBe('-2');
+	});
+});
+
+describe('GetDetailSectionOrder', () => {
+	it('omits damage sections on a miss', () => {
+		expect(GetDetailSectionOrder(false)).toEqual(['hitSummary', 'toHitSummary']);
+	});
+
+	it('includes damage sections around toHitSummary on a hit', () => {
+		expect(GetDetailSectionOrder(true)).toEqual(['hitSummary', 'damageSummary', 'toHitSummary', 'damageRolls']);
 	});
 });
 

--- a/src/utils/Formatting.tsx
+++ b/src/utils/Formatting.tsx
@@ -8,6 +8,28 @@ export function DiceArrayToString(arr: number[]): string {
 	return '[' + arr.map(die => `d${die}`).join(', ') + ']';
 }
 
+export function FormatSignedModifier(modifier: number): string {
+	return modifier >= 0 ? `+${modifier}` : `${modifier}`;
+}
+
+export type DetailSectionKey = 'hitSummary' | 'damageSummary' | 'toHitSummary' | 'damageRolls';
+
+export function GetDetailSectionOrder(isHit: boolean): DetailSectionKey[] {
+	const order: DetailSectionKey[] = ['hitSummary'];
+
+	if (isHit) {
+		order.push('damageSummary');
+	}
+
+	order.push('toHitSummary');
+
+	if (isHit) {
+		order.push('damageRolls');
+	}
+
+	return order;
+}
+
 export function JoinWithElement(arr: JSX.Element[], element: JSX.Element): JSX.Element[] {
 	return arr.flatMap((item, index) =>
 		index < arr.length - 1 ? [item, cloneElement(element, { key: `separator-${index}` })] : [item]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,5 +17,29 @@ export default defineConfig({
 	test: {
 		environment: 'jsdom',
 		setupFiles: ['./src/test/setup.ts'],
+		coverage: {
+			// Scoped to the pure-logic modules the project actually unit-tests (state functions,
+			// reducers, commands, shared utils) — UI-facing files (Steps, pages, LocalStorage,
+			// hooks, history views/forms) are intentionally untested via render tests, so a
+			// global threshold would either fail permanently or have to be set uselessly low.
+			include: [
+				'src/utils/**',
+				'src/pages/*/AttackSheet/AttackSheetStateFunctions.tsx',
+				'src/pages/*/AttackSheet/AttackSheetStateReducer.tsx',
+				'src/pages/*/AttackSheet/Commands/**',
+				'src/pages/gloomstalker/FavoredEnemiesFormFunctions.tsx',
+			],
+			exclude: [
+				'**/*.test.tsx',
+				'**/AttackSheetCommands.tsx',
+				'**/I*AttackSheetCommand.tsx',
+			],
+			thresholds: {
+				lines: 95,
+				functions: 95,
+				branches: 90,
+				statements: 95,
+			},
+		},
 	},
 });


### PR DESCRIPTION
## Summary
- Test coverage was lopsided: every Command class, state-function module, reducer, and `src/utils/*` was fully unit-tested, while everything UI-facing (Step components, page components, history/detail views, forms) had zero coverage — `@testing-library/react`/`jest-dom` are installed but unused.
- Rather than adding render tests, extracts real branching/formatting logic that was embedded directly in component bodies into plain, unit-testable functions, following the repo's existing convention (state-function modules / shared `utils/Formatting.tsx`).
- Adds a `vitest` coverage threshold scoped to the logic-only modules (state functions, reducers, commands, shared utils) so this class of gap doesn't silently reopen — a global threshold isn't meaningful here since UI glue is intentionally untested per this project's logic-first testing preference.

### Extractions
- Gloomstalker `PostDamageRollStep.tsx`'s local `formatDieRolls()` and inline 3-way reroll-button-text ternary → `FormatDieRolls`/`GetRerollButtonText`/`GetIsAlreadyBestRolls` in `AttackSheetStateFunctions.tsx`.
- `FavoredEnemiesForm.tsx`'s trim/dedupe/reject-duplicate add logic and remove logic → `FavoredEnemiesFormFunctions.tsx`. `AddFavoredEnemy` returns an explicit `{ favoredEnemies, added }` result rather than relying on the caller comparing array references to detect a no-op.
- Gloomstalker `AttackHistoryDetails.tsx`'s inline "Total Hit Value" breakdown formula → `FormatHitValueBreakdown` in `AttackSheetStateFunctions.tsx`.
- Both paladin and gloomstalker `AttackHistoryDetails.tsx` built their detail-section list via untested inline `push()` calls gated on `isHit` — identical logic between the two characters, so it moves to one shared `GetDetailSectionOrder` in `utils/Formatting.tsx` instead of being duplicated per page.
- `PostHitRollStep.tsx`'s inline sign-formatting ternary for the attack modifier → shared `FormatSignedModifier` in `utils/Formatting.tsx`.

## Justification
User preference is unit testing pure logic over React Testing Library render tests. This surfaces and locks down game-rule logic (reroll eligibility, favored-enemy validation, hit-value math, section ordering) that previously had no coverage and could only have been caught by a render test or manual QA.

## Future work
- The remaining untested surface (Step/page components, `*LocalStorage.tsx`, `usePaladinSound.tsx`, `AttackHistoryView.tsx`) is pure JSX/wiring glue with no extractable logic found during the audit, or was explicitly deferred (`usePaladinSound.tsx`'s RNG index pick — low value relative to the refactor needed to inject an rng).
- Coverage `include` in `vite.config.ts` lists exact file paths rather than a broader glob, so a newly added pure-logic module won't automatically be covered by the threshold gate unless added there too.

## Test plan
- [x] `npm run test` — 34 files / 152 tests pass
- [x] `npm run test:coverage` — logic-only scope at ~99.5%, threshold (95/95/90/95) enforced and passing
- [x] `npm run build` — type-checks and builds cleanly
- [x] `npm run lint` — no new errors/warnings
- [x] Independent code review (via `code-review` skill) completed, findings addressed, re-verified clean
- [ ] Manual smoke test in a browser (add/remove favored enemy, damage reroll button text, hit-history detail rendering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156TadZ5xGRPU3n8RHSSoxz